### PR TITLE
Improved Janitor template to  allow exclusion of stopped containers

### DIFF
--- a/templates/janitor/1/docker-compose.yml
+++ b/templates/janitor/1/docker-compose.yml
@@ -1,0 +1,16 @@
+cleanup:
+  image: sshipway/docker-cleanup:1.5.2
+  environment:
+    CLEAN_PERIOD: ${FREQUENCY}
+    DELAY_TIME: "900"
+    KEEP_IMAGES: "${KEEP}"
+    KEEP_CONTAINERS: "${KEEPC}"
+  labels:
+     io.rancher.scheduler.global: "true"
+     io.rancher.scheduler.affinity:host_label_ne: "${EXCLUDE_LABEL}"
+  privileged: true
+  tty: false
+  stdin_open: false
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /var/lib/docker:/var/lib/docker

--- a/templates/janitor/1/rancher-compose.yml
+++ b/templates/janitor/1/rancher-compose.yml
@@ -1,0 +1,31 @@
+.catalog:
+  name: "Janitor"
+  version: "v1.5.2"
+  description: "Docker cleanup"
+  uuid: janitor-1
+  questions: 
+    - variable: "FREQUENCY"
+      label: "Frequency"
+      description: "Run the cleanup on a cycle of this many seconds"
+      default: 3600
+      required: true
+      type: "int"
+    - variable: "EXCLUDE_LABEL"
+      label: "Exclude label"
+      description: "Specify a Rancher host label here that will be used to determine on which hosts the Janitor container should not deploy."
+      default: janitor.exclude=true
+      required: true
+      type: "string"
+    - variable: "KEEP"
+      label: "Keep images"
+      description: "A comma separated list of images that should never be removed. These are left-anchored Bash Shell Wildcard patterns."
+      default: "rancher/"
+      required: false
+      type: "string"
+    - variable: "KEEPC"
+      label: "Keep containers"
+      description: "A comma separated list of images that should never have stopped containers removed. These are left-anchored Bash Shell Wildcard patterns."
+      default: "*:*"
+      required: false
+      type: "string"
+

--- a/templates/janitor/README.md
+++ b/templates/janitor/README.md
@@ -10,8 +10,39 @@ scheduling rule (default is `janitor.exclude=true`).
 This will run a task daily (by default) that will delete any unused
 image, and any orphaned volume.  The rancher container images are excluded
 from the list of images to clean up, and you can add your own containers to
-the exclude list if you wish.
+the exclude list if you wish.  It will also remove any stopped containers
+that are taking up space.
 
 This will halp to prevent the /var/lib/docker filesystem from filling up
 with old and unused container images.
 
+### Keep list
+
+You can specify match patterns for unused Images, and stopped Containers, 
+which should be excluded from the cleanup.
+
+The match patterns are comma-separated Left Anchored Bash Shell wildcard
+patterns.  For example, an image called **foo/bar:latest** will match:
+
+* foo/
+* foo/bar
+* \*:latest
+* \*/bar
+* \*:\*
+* fo
+
+However it will notmatch
+
+* foo/baz
+* bar:latest
+* foo/\*:v1
+
+By default, nothing will be matched.  If you want to match everything, 
+then use a pattern **\*:\***
+
+### Warning
+
+If you are using 'run-once' sidekick containers that mount a volume, then
+these containers may be removed by Janitor!  Ensure that the list of
+Containers to keep matches these containers -- setting it to
+'\*:\*' will keep all containers, which is in general the best solution.

--- a/templates/janitor/config.yml
+++ b/templates/janitor/config.yml
@@ -1,7 +1,7 @@
 name: Janitor
 description: |
   Automatic cleanup of unused images on hosts, in order to save disk space.
-version: v1.4.0
+version: v1.5.2
 category: monitoring
 maintainer: Steve Shipway <s.shipway@auckland.ac.nz>
 


### PR DESCRIPTION
This updated template uses a modified container image which allows exclusion of Containers from being automatically cleaned up.  This helps out with cases with run-once containers, or when a Janitor run happens during an Upgrade (preventing a rollback).

A future update will move back to using the meltwater image rather than my fork, if the updates are accepted back into the main branch of the container repository.