### PR TITLE
Fix storage container for Jenkins

### DIFF
--- a/templates/jenkins-ci/0/docker-compose.yml
+++ b/templates/jenkins-ci/0/docker-compose.yml
@@ -17,4 +17,4 @@ jenkins-datavolume:
     - /var/jenkins_home
   labels:
     io.rancher.container.start_once: true
-  entrypoint: /bin/true
+  entrypoint: ["chown", "-R", "1000:1000", "/var/jenkins_home"]


### PR DESCRIPTION
Jenkins was not starting at all due to permissions error. This fix solves issue. Tested.