### PR TITLE
Updates rancher-letsencrypt to v0.2.7

### DIFF
--- a/templates/letsencrypt/1/README.md
+++ b/templates/letsencrypt/1/README.md
@@ -1,0 +1,17 @@
+# Let's Encrypt Certificate Manager
+### About
+The Let's Encrypt Certificate Manager obtains a free (SAN) SSL Certificate from the [Let's Encrypt CA](https://letsencrypt.org/) and adds it to Rancher's certificate store. Once the certificate is created it is scheduled for auto-renewal 14-days before expiration. The renewed certificate is propagated to all applicable load balancer services.
+     
+### Usage
+ 1. Accept the terms of service.
+ 2. Select the API version to use. The Sandbox API should be used for testing purposes.
+ 3. Fill in your email address.
+ 4. Enter the name for storing the certificate in Rancher. If you specify the name of an existing resource it will be overwritten with a renewed certificate.
+ 4. Enter one or more domain names. The first domain will be used as the Common Name property of the certificate.
+ 5. Select the DNS provider that manages the zone enclosing the given domain names.
+ 5. Fill in the required credentials for the provider. AWS Route 53 requires IAM permissions as specified [here](https://github.com/janeczku/rancher-letsencrypt#aws-route-53).
+
+If you want your certificate to be automatically renewed leave the service running. Otherwise you may remove the service once the certificate has appeared in Rancher's certificate store.
+    
+### Suggestions & issue reports
+Please submit suggestions or any issues you find to the [rancher-letsencrypt](https://github.com/janeczku/rancher-letsencrypt) GitHub repo.

--- a/templates/letsencrypt/1/docker-compose.yml
+++ b/templates/letsencrypt/1/docker-compose.yml
@@ -1,0 +1,24 @@
+letsencrypt:
+  image: janeczku/rancher-letsencrypt:v0.2.7
+  environment:
+    EULA: ${EULA}
+    API_VERSION: ${API_VERSION}
+    CERT_NAME: ${CERT_NAME}
+    EMAIL: ${EMAIL}
+    DOMAINS: ${DOMAINS}
+    PUBLIC_KEY_TYPE: ${PUBLIC_KEY_TYPE}
+    RENEWAL_TIME: ${RENEWAL_TIME}
+    PROVIDER: ${PROVIDER}
+    CLOUDFLARE_EMAIL: ${CLOUDFLARE_EMAIL}
+    CLOUDFLARE_KEY: ${CLOUDFLARE_KEY}
+    DO_ACCESS_TOKEN: ${DO_ACCESS_TOKEN}
+    AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+    AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+    DNSIMPLE_EMAIL: ${DNSIMPLE_EMAIL}
+    DNSIMPLE_KEY: ${DNSIMPLE_KEY}
+    DYN_CUSTOMER_NAME: ${DYN_CUSTOMER_NAME}
+    DYN_USER_NAME: ${DYN_USER_NAME}
+    DYN_PASSWORD: ${DYN_PASSWORD}
+  labels:
+    io.rancher.container.create_agent: 'true'
+    io.rancher.container.agent.role: 'environment'

--- a/templates/letsencrypt/1/rancher-compose.yml
+++ b/templates/letsencrypt/1/rancher-compose.yml
@@ -1,0 +1,117 @@
+.catalog:
+  name: "Let's Encrypt"
+  version: 0.2.7
+  description: "Trusted SSL certificates at zero cost"
+  minimum_rancher_version: v0.63.0
+  questions:
+    - variable: "EULA"
+      label: "I Agree to the Let's Encrypt TOS"
+      description: "Read https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"
+      required: true
+      type: "enum"
+      options:
+        - "Yes"
+        - "No"
+    - variable: "API_VERSION"
+      label: "Let's Encrypt API Version"
+      description: "Select the API version used for issuing the certificate. Use 'Sandbox' for testing only."
+      required: true
+      type: "enum"
+      default: "Production"
+      options:
+        - "Production"
+        - "Sandbox"
+    - variable: "EMAIL"
+      label: "Your Email Address"
+      description: "Enter the email address to be associated with the Let's Encrypt account."
+      required: true
+      type: "string"
+    - variable: "CERT_NAME"
+      label: "Certificate Name"
+      description: "Name for storing the certificate in Rancher. If this matches an existing certificate it will be updated."
+      required: true
+      type: "string"
+    - variable: "DOMAINS"
+      label: "Domain Names"
+      description: "Comma delimited list of domains starting with the 'Common Name', e.g.: 'example.com, dev.example.com'."
+      required: true
+      type: "string"
+    - variable: "PUBLIC_KEY_TYPE"
+      label: "Public Key Algorithm"
+      description: "Select one of the supported key types."
+      required: true
+      type: "enum"
+      default: RSA-2048
+      options:
+        - RSA-2048
+        - RSA-4096
+        - RSA-8192
+        - ECDSA-256
+        - ECDSA-384
+    - variable: "RENEWAL_TIME"
+      label: "Renewal Time of Day (00-23)"
+      description: "Set the time of day (UTC in hours) at which certificate renewals should run."
+      default: 12
+      required: true
+      type: int
+    - variable: "PROVIDER"
+      label: "DNS Provider"
+      description: "Select the DNS provider used for domain verification."
+      required: true
+      type: "enum"
+      options:
+        - CloudFlare
+        - DigitalOcean
+        - Route53
+        - DNSimple
+        - Dyn
+    - variable: "AWS_ACCESS_KEY"
+      label: "AWS Access Key Id"
+      description: "Enter the Access Key Id for your AWS account."
+      type: "string"
+      required: false
+    - variable: "AWS_SECRET_KEY"
+      label: "AWS Secret Access Key"
+      description: "Enter the Secret Access Key for your AWS account."
+      type: "string"
+      required: false
+    - variable: "CLOUDFLARE_EMAIL"
+      label: "CloudFlare Email Address"
+      description: "Enter the email address associated with your CloudFlare account."
+      type: "string"
+      required: false
+    - variable: "CLOUDFLARE_KEY"
+      label: "CloudFlare API Key"
+      description: "Enter the Global API Key for your CloudFlare account."
+      type: "string"
+      required: false
+    - variable: "DO_ACCESS_TOKEN"
+      label: "DigitalOcean API Access Token"
+      description: "Enter the Personal Access Token for your DigitalOcean account."
+      type: "string"
+      required: false
+    - variable: "DNSIMPLE_EMAIL"
+      label: "DNSimple Email Address"
+      description: "Enter the email address associated with your DNSimple account."
+      type: "string"
+      required: false
+    - variable: "DNSIMPLE_KEY"
+      label: "DNSimple API Key"
+      description: "Enter your DNSimple API key."
+      type: "string"
+      required: false
+    - variable: "DYN_CUSTOMER_NAME"
+      label: "Dyn Customer Name"
+      description: "Enter your Dyn customer name."
+      type: "string"
+      required: false
+    - variable: "DYN_USER_NAME"
+      label: "Dyn User Name"
+      description: "Enter your Dyn user name."
+      type: "string"
+      required: false
+    - variable: "DYN_PASSWORD"
+      label: "Dyn Password"
+      description: "Enter your Dyn password."
+      type: "string"
+      required: false

--- a/templates/letsencrypt/config.yml
+++ b/templates/letsencrypt/config.yml
@@ -1,7 +1,7 @@
 name: "Let's Encrypt"
 description: |
   Trusted SSL certificates at zero cost
-version: 0.2.5
+version: 0.2.7
 category: Security
 maintainer: "Jan Broer <jan@festplatte.eu.org>"
 license: The MIT License


### PR DESCRIPTION
**Changes:**
* New DNS providers: Dyn, DNSimple
* Support for claiming existing Rancher certificate by name
* Handle API connection errors on container start (when there is a delay with ipsec tunnel creation)