### PR TITLE
Update template

### DIFF
--- a/templates/nuxeo/0/docker-compose.yml
+++ b/templates/nuxeo/0/docker-compose.yml
@@ -6,7 +6,7 @@ postgres-datavolume:
   entrypoint: chown -R postgres:postgres /var/lib/postgresql/data
   volume_driver: ${volumedriver}
   volumes:
-    - nuxeo-postgres:/var/lib/postgresql/data
+    - /var/lib/postgresql/data
 
 postgres:
   image: nuxeo/postgres
@@ -25,6 +25,7 @@ elasticsearch-masters:
   labels:
     io.rancher.container.hostname_override: container_name
     io.rancher.sidekicks: elasticsearch-base-master,elasticsearch-datavolume-masters
+  volume_driver: ${volumedriver}
 elasticsearch-datavolume-masters:
   labels:
     elasticsearch.datanode.config.version: '0'
@@ -52,6 +53,7 @@ redis:
   tty: true
   image: redis:3.0.3
   stdin_open: true
+  volume_driver: ${volumedriver}
 
 nuxeo-datavolume:
   labels:
@@ -73,6 +75,8 @@ nuxeo:
     NUXEO_ES_HOSTS: elasticsearch:9300
     NUXEO_DATA: /data/nuxeo/data/
     NUXEO_LOG: /data/nuxeo/log/
+    NUXEO_REDIS_HOST: redis
+    NUXEO_URL: ${url}
   labels:
     io.rancher.sidekicks: nuxeo-datavolume    
     io.rancher.container.hostname_override: container_name

--- a/templates/nuxeo/0/rancher-compose.yml
+++ b/templates/nuxeo/0/rancher-compose.yml
@@ -22,7 +22,7 @@
       description: "The URL that this nuxeo instance should serve"
       label: "Nuxeo URL"
       type: "string"
-      required: "true"
+      required: true
       default: "http://localhost:8080/"    
     - variable: volumedriver
       type: "string"

--- a/templates/nuxeo/0/rancher-compose.yml
+++ b/templates/nuxeo/0/rancher-compose.yml
@@ -18,12 +18,19 @@
       description: |
         List of Nuxeo packages 
       default: nuxeo-web-mobile nuxeo-drive nuxeo-diff nuxeo-spreadsheet nuxeo-dam nuxeo-template-rendering nuxeo-template-rendering-samples nuxeo-showcase-content
-    - variable: "volumedriver"
+    - variable: url
+      description: "The URL that this nuxeo instance should serve"
+      label: "Nuxeo URL"
+      type: "string"
+      required: "true"
+      default: "http://localhost:8080/"    
+    - variable: volumedriver
       type: "string"
       label: "Volume driver"
       description: |
-        Specifiy docker volume driver  to use
+        Specifiy docker volume driver to use
       default: local
+
 
 nuxeo:
   scale: 1

--- a/templates/nuxeo/README.md
+++ b/templates/nuxeo/README.md
@@ -1,0 +1,13 @@
+# Nuxeo
+
+
+This templates deploys a Nuxeo server with all its companions (Elasticsearch, Redis and Postgres) to be able to run Nuxeo on top of you Rancher infrastructure
+
+
+# How to use it ?
+
+Just create and launch the stack. After that, you have to point a load balancer of you infrasctructure to the internal stack load balancer. 
+
+We made this choice, since it allows to start several Nuxeo server instance on the same infrastructure.
+
+After that you can login with the regular user/password combination Administrator/Administrator.


### PR DESCRIPTION
Solves the following problems : 

- postgresql volume name was hardcoded, which prevented to launch to stack on the same host. 
- redis was not used by nuxeo
- nuxeo url can now be customized