### PR TITLE
Add retainIP option to MongoDB catalog template

### DIFF
--- a/templates/MongoDB/0/rancher-compose.yml
+++ b/templates/MongoDB/0/rancher-compose.yml
@@ -13,6 +13,7 @@
       default: "rs0"
 mongo-cluster:
   scale: 3
+  retain_ip: true
   metadata:
     mongo:
       yml:

--- a/templates/MongoDB/1/rancher-compose.yml
+++ b/templates/MongoDB/1/rancher-compose.yml
@@ -13,6 +13,7 @@
       default: "rs0"
 mongo-cluster:
   scale: 3
+  retain_ip: true
   metadata:
     mongo:
       yml:


### PR DESCRIPTION
Set retain_ip to true to make sure any upgrade to the mongodb service doesn't break the configuration for the replica set.