### PR TITLE
Upgrade Datadog Cattle template

### DIFF
--- a/templates/datadog/2/docker-compose.yml
+++ b/templates/datadog/2/docker-compose.yml
@@ -1,0 +1,33 @@
+datadog-init:
+  image: janeczku/datadog-rancher-init:v2.0
+  net: none
+  command: /bin/true
+  volumes:
+    - /opt/rancher
+  labels:
+    io.rancher.container.start_once: 'true'
+    io.rancher.container.pull_image: always
+datadog-agent:
+  image: datadog/docker-dd-agent:11.0.580
+  entrypoint: /opt/rancher/entrypoint-wrapper.py
+  command:
+    - supervisord
+    - -n
+    - -c
+    - /etc/dd-agent/supervisor.conf
+  restart: always
+  environment:
+    API_KEY: ${api_key}
+    DOGSTATSD_ONLY: "${statsd_standalone}"
+    STATSD_METRIC_NAMESPACE: ${statsd_namespace}
+    HOST_LABELS: ${host_labels}
+    CONTAINER_LABELS: ${container_labels}
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /proc/:/host/proc/:ro
+    - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+  volumes_from:
+    - datadog-init
+  labels:
+    io.rancher.scheduler.global: "${global_service}"
+    io.rancher.sidekicks: 'datadog-init'

--- a/templates/datadog/2/rancher-compose.yml
+++ b/templates/datadog/2/rancher-compose.yml
@@ -1,0 +1,49 @@
+.catalog:
+  name: Datadog
+  version: 11.0.580-rancher1
+  description: Real-time performance tracking and visualization of your container-based application deployment
+  minimum_rancher_version: v0.46.0
+  questions:
+    - variable: api_key
+      label: Datadog Api Key
+      description: Your Datadog API key
+      required: true
+      type: string
+    - variable: global_service
+      label: Global Service
+      description: |
+        Enable this option to capture system and Docker metrics environment-wide.
+        One instance of the Datadog Agent container will be started on every host.
+      required: true
+      type: boolean
+      default: true
+    - variable: host_labels
+      label: Map Host Labels to Datadog Tags
+      description: |
+        Comma delimited list of host labels to map to Datadog key:value tags.
+        Example: 'region, instancetype'
+      required: false
+      type: string
+    - variable: container_labels
+      label: Map Container Labels to Datadog Tags
+      description: |
+        Comma delimited list of service labels to map to Datadog key:value tags.
+        'io.rancher.stack.name' and 'io.rancher.stack_service.name' are enabled by default.
+        Example: 'app, tier'
+      required: false
+      type: string
+    - variable: statsd_standalone
+      label: Standalone StatsD
+      description: |
+        Enable this option to run just the DogStatsD daemon without the full agent.
+        The daemon aggregates and forwards StatsD metrics received on port 8125/udp.
+        You probably want to disable the Global Service option with this.
+      required: true
+      type: boolean
+      default: false
+    - variable: statsd_namespace
+      label: StatsD Metric Namespace
+      description: |
+        Optional namespace for aggregated StatsD metrics.
+      required: false
+      type: string

--- a/templates/datadog/README.md
+++ b/templates/datadog/README.md
@@ -1,8 +1,8 @@
-# DataDog Agent & DogStatsD
+# Datadog Agent & DogStatsD
 
-This service uses the [official](https://www.github.com/DataDog/docker-dd-agent) Datadog Agent image and a sidekick data volume containing a customized entrypoint script for improved integration with the Rancher environment.
+This template deploys a Datadog Agent stack consisting of the official [docker-dd-agent image](https://www.github.com/Datadog/docker-dd-agent) and a sidekick config volume with a custom entrypoint script for improved integration with the Rancher Cattle environment:
 
-* The `hostname` reported to DataDog is the actual name of the host
-* You may specify `host labels` which are used as DataDog tags
-* Service will be deployed globally by default so that every host is monitored by a `DataDog Agent`
-* Alternatively you may deploy just a single `DogStatsD` instance which then acts as a metrics aggregator for other services
+* Reports the actual name of the host instead of the container's hostname
+* Let's you specify `host` and `service` labels to be mapped to Datadog tags
+* Starts as global service by default so that system and Docker metrics from every host are captured
+* Allows deployment as a standalone `DogStatsD` service that aggregates StatsD metrics sent from applications

--- a/templates/datadog/config.yml
+++ b/templates/datadog/config.yml
@@ -1,7 +1,7 @@
 name: Datadog
 description: |
   Real-time performance tracking and visualization of your container-based application deployment
-version: 11.0.570-rancher1
+version: 11.0.580-rancher1
 category: Monitoring
-maintainer: "Jan Broer <jan@festplatte.eu.org>"
-license: The MIT License
+maintainer: "Jan Bruder <jan@rancher.com>"
+license: Apache License 2.0


### PR DESCRIPTION
datadog-rancher-init:v2.0
datadog/docker-dd-agent:11.0.580

Changes: Support for mapping Rancher service labels to Datadog tags