### PR TITLE
volumes_form -> volumes_from typo

### DIFF
--- a/templates/consul-registrator/0/docker-compose.yml
+++ b/templates/consul-registrator/0/docker-compose.yml
@@ -46,7 +46,7 @@ consul:
   environment:
     CONSUL_LOCAL_CONFIG: "{\"leave_on_terminate\": true}"
     CONSUL_BIND_INTERFACE: eth0
-  volumes_form:
+  volumes_from:
     - consul-data
   log_opt: {}
   image: consul:v0.6.4


### PR DESCRIPTION
When attempting to create a consul-registrator stack, I spotted this typo.