### PR TITLE
Remove option to set Privileged mode, as this cannot be parameterised

### DIFF
--- a/templates/janitor/2/docker-compose.yml
+++ b/templates/janitor/2/docker-compose.yml
@@ -11,7 +11,6 @@ cleanup:
      io.rancher.scheduler.global: "true"
      io.rancher.scheduler.affinity:host_label_ne: "${EXCLUDE_LABEL}"
   net: none
-  privileged: ${PRIVILEGED_MODE}
   tty: false
   stdin_open: false
   volumes:

--- a/templates/janitor/2/rancher-compose.yml
+++ b/templates/janitor/2/rancher-compose.yml
@@ -28,9 +28,4 @@
       default: "*:*"
       required: false
       type: "string"
-    - variable: "PRIVILEGED_MODE"
-      label: "Run janitor in privileged mode"
-      description: "In hardened environments containers must be privileged to access the bind-mounted unix:///var/run/docker.sock. This is not the default case."
-      default: false
-      required: true
-      type: "boolean"
+


### PR DESCRIPTION
The current template does not work with docker-compose.  This removes the configurability of the Privileged mode so that it will.  Note that hardened Docker setups will not be able to run Rancher without Privileged mode, and clearing of orphaned volumes requires it.