### PR TITLE
Allow custom kopf and kibana public ports

### DIFF
--- a/templates/elasticsearch-2/0/docker-compose.yml
+++ b/templates/elasticsearch-2/0/docker-compose.yml
@@ -98,7 +98,7 @@ elasticsearch-base-clients:
 kopf:
   image: rancher/kopf:v0.4.0
   ports:
-    - "80:80"
+    - "${kopf_port}:80"
   environment:
     KOPF_SERVER_NAME: 'es.dev'
     KOPF_ES_SERVERS: 'es-clients:9200'

--- a/templates/elasticsearch-2/0/rancher-compose.yml
+++ b/templates/elasticsearch-2/0/rancher-compose.yml
@@ -14,7 +14,7 @@
       description: "Unique public port for kopf"
       type: "int"
       default: 80
-      required: false
+      required: true
 elasticsearch-masters:
   metadata:
     elasticsearch:

--- a/templates/elasticsearch-2/0/rancher-compose.yml
+++ b/templates/elasticsearch-2/0/rancher-compose.yml
@@ -9,6 +9,12 @@
       type: "string"
       required: true
       default: "es"
+    - variable: "kopf_port"
+      label: "Public Port"
+      description: "Unique public port for kopf"
+      type: "int"
+      default: 80
+      required: false
 elasticsearch-masters:
   metadata:
     elasticsearch:

--- a/templates/kibana/1/docker-compose.yml
+++ b/templates/kibana/1/docker-compose.yml
@@ -1,6 +1,6 @@
 kibana-vip:
   ports:
-  - 80:80
+  - "${public_port}:80"
   restart: always
   tty: true
   image: rancher/load-balancer-service

--- a/templates/kibana/1/rancher-compose.yml
+++ b/templates/kibana/1/rancher-compose.yml
@@ -9,6 +9,13 @@
       type: "service"
       required: true
       default: "es/elasticsearch-clients"
+    - variable: "public_port"
+      label: "Public Port"
+      description: "Unique public port for Kibana"
+      type: "int"
+      default: 80
+      required: false
+
 nginx-proxy:
   metadata:
     nginx:

--- a/templates/kibana/1/rancher-compose.yml
+++ b/templates/kibana/1/rancher-compose.yml
@@ -14,7 +14,7 @@
       description: "Unique public port for Kibana"
       type: "int"
       default: 80
-      required: false
+      required: true
 
 nginx-proxy:
   metadata:


### PR DESCRIPTION
An ELK stack with elastisearch+logstash+kibana is super simple to setup in Rancher.  Yet it seems no one has done this via the catalog, *using a single rancher host*.  Elastisearch has a kopf container which binds to port 80 on the host.  Kibana sidekick also binds to port 80 on the host.  So this is obviously a problem.  

This PR is to allow for custom public ports for both kopf and kibana so that both can run on the same host.  Not ideal for production, but super useful for proof-of-concepts and demos.  