### PR TITLE
templace/ecr: AWS credentials not requiered

### DIFF
--- a/templates/ecr/2/docker-compose.yml
+++ b/templates/ecr/2/docker-compose.yml
@@ -1,0 +1,12 @@
+ecr-updater:
+  environment:
+    AWS_ACCESS_KEY_ID: ${aws_access_key_id}
+    AWS_SECRET_ACCESS_KEY: ${aws_secret_access_key}
+    AWS_REGION: ${aws_region}
+  labels:
+    io.rancher.container.pull_image: always
+    io.rancher.container.create_agent: 'true'
+    io.rancher.container.agent.role: environment
+  tty: true
+  image: objectpartners/rancher-ecr-credentials:1.1.0
+  stdin_open: true

--- a/templates/ecr/2/rancher-compose.yml
+++ b/templates/ecr/2/rancher-compose.yml
@@ -1,0 +1,24 @@
+.catalog:
+  name: "ECR Credential Updater"
+  version: "v1.1.0"
+  description: "Updates credentials for ECR in Rancher"
+  uuid: ecr-3
+  questions:
+    - variable: "aws_access_key_id"
+      label: "AWS Access Key ID"
+      description: "AWS API Access Key to use for obtaining ECR credentials. Not required if using IAM roles."
+      required: false
+      type: "string"
+    - variable: "aws_secret_access_key"
+      label: "AWS Secret Access Key"
+      description: "AWS API Secret Key to use for obtaining ECR credentials. Not required if using IAM roles."
+      required: false
+      type: "string"
+    - variable: "aws_region"
+      label: "AWS Region"
+      description: "AWS Region that hosts the ECR"
+      default: us-east-1
+      required: true
+      type: "string"
+ecr-updater:
+  scale: 1

--- a/templates/ecr/README.md
+++ b/templates/ecr/README.md
@@ -1,6 +1,7 @@
 # Rancher ECR Credentials Updater
 
-This is Docker container that when executed will update the Docker registry credentials in Rancher for an Amazon Elastic Container Registry.
+This is Docker container that when executed will update the Docker registry
+credentials in Rancher for an Amazon Elastic Container Registry.
 
 ## Why is this needed?
 
@@ -12,20 +13,34 @@ Rancher only supports registries that authenticate with a username and password.
 
 ## How to use
 
-Run this container with the following environment variables:
-* `AWS_REGION` - the AWS region of the ECR registry
-* `AWS_ACCESS_KEY_ID`
-* `AWS_SECRET_ACCESS_KEY`
+In order to authenticate with AWS ECR, this Docker container uses the default
+chain of [credential providers](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
+
+The only requirement for running this application is to specify the AWS region
+using the `AWS_REGION` environment variable.
+
+AWS credentials are loaded using the default [AWS credential chain](http://docs.aws.amazon.com/sdk-for-go/latest/v1/developerguide/configuring-sdk.title.html).
+Credentials are loaded in the following order:
+
+1. Environment variables (Specify `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` *(optional)*)
+1. Shared credentials file (mount a volume to `/root/.aws` that contains `credentials` and `config` files and specify `AWS_PROFILE`)
+1. IAM Instance Profile (if running on EC2)
+
+**NOTE**: Cross account roles are not currently supported.
 
 Add the following labels to the service in Rancher:
 * `io.rancher.container.create_agent: true`
 * `io.rancher.container.agent.role: environment`
 
-These labels will cause Rancher to provision an API key for this service and create the `CATTLE_URL`, `CATTLE_ACCESS_KEY`, and `CATTLE_SECRET_KEY` environment variables.
+These labels will cause Rancher to provision an API key for this service and
+create the `CATTLE_URL`, `CATTLE_ACCESS_KEY`, and `CATTLE_SECRET_KEY`
+environment variables.
 
 ## Running container outside of Rancher
 
-If you are running this container outside of a Rancher managed environment, then you must provide the following envvars in additional to the ones above.
+If you are running this container outside of a Rancher managed environment, then
+you must provide the following environment variables in additional to the ones
+above.
 * `CATTLE_URL` - the url of the Rancher server to update
 * `CATTLE_ACCESS_KEY`
 * `CATTLE_SECRET_KEY`
@@ -36,12 +51,18 @@ $ docker run -d -e AWS_REGION=us-east-1 -e AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID 
 
 ## Notes
 
-The AWS credentials must correspond to an IAM user that has permissions to call the ECR `GetToken` API.
-The application then parses the resulting response to retrieve the ECR registry URL, username, and password.
-The returned registry URL, is used to discover the corresponding registry in Rancher.
+The AWS credentials must correspond to an IAM user that has permissions to call
+the ECR `GetToken` API.
+The application then parses the resulting response to retrieve the ECR registry
+URL, username, and password.
+The returned registry URL, is used to discover the corresponding registry in
+Rancher.
 
 Rancher stores registries by environment.
-If multiple environments exists, one instance of this container must be run per environment.
-Rancher credentials are tied to an environment, so specifying them will indicate which environment to update in Rancher.
+If multiple environments exists, one instance of this container must be run per
+environment.
+Rancher credentials are tied to an environment, so specifying them will indicate
+which environment to update in Rancher.
 
-__NOTE__: This application runs on a 6 hour loop. It's possible there could be a slight gap where the credentials expire before this program updates them.
+__NOTE__: This application runs on a 6 hour loop. It's possible there could be a
+slight gap where the credentials expire before this program updates them.

--- a/templates/ecr/config.yml
+++ b/templates/ecr/config.yml
@@ -1,6 +1,6 @@
 name: ECR Credential Updater
 description: |
   Automatically updates AWS EC2 Container Registry credentials in Rancher.
-version: v1.0.1
+version: v1.1.0
 category: Applications
 maintainer: John Engelman <john.engelman@objectpartners.com>


### PR DESCRIPTION
This enable support to use credentials resolved from the IAM Instance Profile if used. This was added to this project a few months ago. Also add reference to this in the readme