### PR TITLE
New convoy-efs template version

### DIFF
--- a/templates/convoy-efs/1/docker-compose.yml
+++ b/templates/convoy-efs/1/docker-compose.yml
@@ -1,0 +1,23 @@
+convoy-efs:
+  labels:
+    io.rancher.container.create_agent: 'true'
+    io.rancher.scheduler.global: 'true'
+  privileged: true
+  pid: host
+  volumes:
+    - /lib/modules:/lib/modules:ro
+    - /proc:/host/proc
+    - /var/run:/host/var/run
+    - /run:/host/run
+    - /etc/docker/plugins:/etc/docker/plugins
+  image: rancher/convoy-agent:v0.20.0
+  command: volume-agent-efs
+
+convoy-efs-storagepool:
+  labels:
+    io.rancher.container.create_agent: 'true'
+  image: rancher/convoy-agent:v0.20.0
+  volumes:
+    - /var/run:/host/var/run
+    - /run:/host/run
+  command: storagepool-agent

--- a/templates/convoy-efs/1/rancher-compose.yml
+++ b/templates/convoy-efs/1/rancher-compose.yml
@@ -1,0 +1,42 @@
+.catalog:
+    name: "Convoy EFS"
+    version: "v0.1.0"
+    description: "Convoy EFS - Docker volume plugin"
+    questions:
+     - variable: "EFS_SERVER"
+       description: "DNS name of AWS EFS"
+       label: "EFS Server"
+       required: true
+       type: "string"
+     - variable: "MOUNT_DIR"
+       label: "Mount Directory"
+       description: "The directory on the EFS server to mount"
+       type: "string"
+       required: true
+
+convoy-efs:
+    metadata:
+        efs_server: "${EFS_SERVER}"
+        mount_dir: "${MOUNT_DIR}"
+        mount_opts: "${MOUNT_OPTS}"
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2
+
+convoy-efs-storagepool:
+    metadata:
+        efs_server: "${EFS_SERVER}"
+        mount_dir: "${MOUNT_DIR}"
+        mount_opts: "${MOUNT_OPTS}"
+    scale: 1
+    health_check:
+        request_line: GET /healthcheck HTTP/1.0
+        port: 10241
+        interval: 2000
+        response_timeout: 2000
+        unhealthy_threshold: 3
+        healthy_threshold: 2

--- a/templates/convoy-efs/1/rancher-compose.yml
+++ b/templates/convoy-efs/1/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
     name: "Convoy EFS"
-    version: "v0.1.0"
+    version: "v0.2.0"
     description: "Convoy EFS - Docker volume plugin"
     questions:
      - variable: "EFS_SERVER"

--- a/templates/convoy-efs/config.yml
+++ b/templates/convoy-efs/config.yml
@@ -1,5 +1,5 @@
 name: Convoy EFS
 description: |
   Docker Volume Manager for AWS EFS-backed Volumes
-version: v0.1.0
+version: v0.2.0
 category: Rancher Services


### PR DESCRIPTION
Replaced `efs_id` and `aws_region` metadata with `efs_server` and bumped the template version.