### PR TITLE
Logspout + Prometheus fixes

### DIFF
--- a/templates/logspout/0/docker-compose.yml
+++ b/templates/logspout/0/docker-compose.yml
@@ -11,5 +11,5 @@ logspout:
     io.rancher.scheduler.global: 'true'
     io.rancher.container.hostname_override: container_name
   tty: true
-  image: rancher/logspout-logstash:v0.2.0
+  image: bekt/logspout-logstash:latest
   stdin_open: true

--- a/templates/logspout/1/docker-compose.yml
+++ b/templates/logspout/1/docker-compose.yml
@@ -10,5 +10,5 @@ logspout:
     io.rancher.scheduler.global: 'true'
     io.rancher.container.hostname_override: container_name
   tty: true
-  image: rancher/logspout-logstash:v0.2.0
+  image: bekt/logspout-logstash:latest
   stdin_open: true


### PR DESCRIPTION
Logpsout didn't work with ELS 2.0, see issue:
https://forums.rancher.com/t/elk-stack-in-catalog-not-working/2890/4
Prometheus was really old, updated to latest version.