### PR TITLE
Fixes versions in templates

### DIFF
--- a/swarm-templates/wordpress/0/rancher-compose.yml
+++ b/swarm-templates/wordpress/0/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Wordpress"
-  version: latest-rancher1
+  version: 1.0.0-latest-rancher1
   description: "Blog tool, publishing platform and CMS"
   minimum_rancher_version: v1.0.0-rc2
   questions:

--- a/swarm-templates/wordpress/config.yml
+++ b/swarm-templates/wordpress/config.yml
@@ -1,5 +1,5 @@
 name: Wordpress
 description: |
   Blog tool, publishing platform and CMS
-version: latest-rancher1
+version: 1.0.0-latest-rancher1
 category: Blogging

--- a/templates/alfresco/0/rancher-compose.yml
+++ b/templates/alfresco/0/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Alfresco"
-  version: "5.1 201605-GA"
+  version: "5.1.0-201605-GA"
   description: "Alfresco Electronic Document Management"
   uuid: alfresco-5.1-201605-1
   minimum_rancher_version: v0.56.0

--- a/templates/alfresco/config.yml
+++ b/templates/alfresco/config.yml
@@ -1,5 +1,5 @@
 name: Alfresco
 description: |
   An ECM and BPM platform.
-version: 5.1 201605-GA
+version: 5.1.0-201605-GA
 category: ECM


### PR DESCRIPTION
Some templates in community catalogs do not have versions in the correct format. They are used by catalog-service, and the library semver being used by catalog service to compare versions requires all versions to be of the format: `X.Y.Z` or `X.Y.Z-alpha` etc, where X, Y and Z have to be integers. 