### PR TITLE
Fix MongoDB replicaset template for Kubernetes

### DIFF
--- a/kubernetes-templates/MongoDB/0/mongo-controller.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-controller.yaml
@@ -42,7 +42,7 @@ spec:
       volumes:
       - name: mongo-datadir
         hostPath:
-          path: /data/db
+          path: ${mongo_volume}
       - name: utility
         emptyDir: {}
     metadata:

--- a/kubernetes-templates/MongoDB/0/mongo-controller.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-controller.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     spec:
       containers:
-      - image: husseingalal/mongo-k8s-config
+      - image: husseingalal/mongo-k8s-config:v0.2.0
         name: mongo-config
         volumeMounts:
         - mountPath: /opt/rancher/bin

--- a/kubernetes-templates/MongoDB/0/mongo-controller.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-controller.yaml
@@ -9,23 +9,42 @@ spec:
   template:
     spec:
       containers:
+      - image: husseingalal/mongo-k8s-config
+        name: mongo-config
+        volumeMounts:
+        - mountPath: /opt/rancher/bin
+          name: utility
+        stdin: true
+        tty: true
       - name: mongo-sec
-        image: husseingalal/mongo-k8s
+        image: mongo:3.4
         ports:
           - containerPort: 27017
         volumeMounts:
-          - name: mongo-ephermal-storage
+          - name: mongo-datadir
             mountPath: /data/db
+          - mountPath: /opt/rancher/bin
+            name: utility
         command:
-          - /run.sh
+          - /opt/rancher/bin/run.sh
           - mongod
           - "--replSet"
           - rs0
           - "--smallfiles"
           - "--noprealloc"
+        env:
+        - name: PRIMARY
+          value: "false"
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
       volumes:
-        - name: mongo-ephermal-storage
-          emptyDir: {}
+      - name: mongo-datadir
+        hostPath:
+          path: /data/db
+      - name: utility
+        emptyDir: {}
     metadata:
       labels:
         secondary: "true"

--- a/kubernetes-templates/MongoDB/0/mongo-master.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-master.yaml
@@ -9,33 +9,49 @@ spec:
     - port: 27017
       targetPort: 27017
   selector:
-    name: mongo-master
+    name: mongo-primary
 ---
 apiVersion: v1
 kind: Pod
 metadata:
   labels:
-          name: mongo-master
-  name: mongo-master
+    name: mongo-primary
+  name: mongo-primary
 spec:
   containers:
-    - name: mongo-master
-      image: "husseingalal/mongo-k8s"
+    - name: mongo-config
+      image: husseingalal/mongo-k8s-config
+      volumeMounts:
+      - mountPath: /opt/rancher/bin
+        name: utility
+      stdin: true
+      tty: true
+    - name: mongo-primary
+      image: mongo:3.4
       env:
-        - name: PRIMARY
-          value: "true"
+      - name: PRIMARY
+        value: "true"
+      - name: POD_IP
+        valueFrom:
+          fieldRef:
+            fieldPath: status.podIP
       ports:
         - containerPort: 27017
       command:
-        - /run.sh
+        - /opt/rancher/bin/run.sh
         - mongod
         - "--replSet"
         - rs0
         - "--smallfiles"
         - "--noprealloc"
       volumeMounts:
+        - mountPath: /opt/rancher/bin
+          name: utility
         - mountPath: /data/db
-          name: mongo-primary-ephermal-storage
+          name: mongo-datadir
   volumes:
-    - name: mongo-primary-ephermal-storage
-      emptyDir: {}
+  - name: mongo-datadir
+    hostPath:
+      path: /data/db
+  - name: utility
+    emptyDir: {}

--- a/kubernetes-templates/MongoDB/0/mongo-master.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-master.yaml
@@ -52,6 +52,6 @@ spec:
   volumes:
   - name: mongo-datadir
     hostPath:
-      path: /data/db
+      path: ${mongo_volume}
   - name: utility
     emptyDir: {}

--- a/kubernetes-templates/MongoDB/0/mongo-master.yaml
+++ b/kubernetes-templates/MongoDB/0/mongo-master.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   containers:
     - name: mongo-config
-      image: husseingalal/mongo-k8s-config
+      image: husseingalal/mongo-k8s-config:v0.2.0
       volumeMounts:
       - mountPath: /opt/rancher/bin
         name: utility

--- a/kubernetes-templates/MongoDB/0/rancher-compose.yml
+++ b/kubernetes-templates/MongoDB/0/rancher-compose.yml
@@ -9,3 +9,8 @@
       type: int
       default: 2
       description: "should be even number"
+    - variable: "mongo_volume"
+      label: "hostpath volume for mongodb"
+      required: true
+      type: string
+      default: "/data/db"


### PR DESCRIPTION
* Set primary variable to false on secondary rc
* Add sidekick config container to mongo base image
* Use Downward API to find Pod's IP
* Change the name of the mongo service to mongo-primary
* Change storage type to host's volume

The PR tested and worked on Rancher v1.2.0