### PR TITLE
make distinct templates for different versions

### DIFF
--- a/templates/plone/0/README.md
+++ b/templates/plone/0/README.md
@@ -9,4 +9,4 @@ Just create and launch the stack.
 
 After that you can login with the regular user/password combination admin/admin.
 
-For usage see [Plone documentation site](http://docs.plone.org/4/en/). 
+For more information on how to configure and use Plone visit [Plone 4 documentation site](http://docs.plone.org/4/en/). 

--- a/templates/plone/0/README.md
+++ b/templates/plone/0/README.md
@@ -1,11 +1,12 @@
-# Plone
+# Plone 4.3
 
 
-This templates deploys a Plone server with all its companions (Zeoserver) to be able to run Plone on top of you Rancher infrastructure
-
+This templates deploys a Plone 4.3 server with all its companions (Zeoserver) to be able to run Plone on top of you Rancher infrastructure.
 
 # How to use it ?
 
 Just create and launch the stack.
 
 After that you can login with the regular user/password combination admin/admin.
+
+For usage see [Plone documentation site](http://docs.plone.org/4/en/). 

--- a/templates/plone/0/docker-compose.yml
+++ b/templates/plone/0/docker-compose.yml
@@ -10,7 +10,7 @@ zeoserver:
   command: ["zeoserver"]
 
 plone:
-  image: plone:${version}
+  image: plone:4.3
   labels:
     io.rancher.scheduler.affinity:host_label: ${host_label}
     io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.community.plone=true

--- a/templates/plone/1/README.md
+++ b/templates/plone/1/README.md
@@ -1,0 +1,12 @@
+# Plone 5.0
+
+
+This templates deploys a Plone 5.0 server with all its companions (Zeoserver) to be able to run Plone on top of you Rancher infrastructure.
+
+# How to use it ?
+
+Just create and launch the stack.
+
+After that you can login with the regular user/password combination admin/admin.
+
+For usage see [Plone documentation site](http://docs.plone.org/5/en/).

--- a/templates/plone/1/README.md
+++ b/templates/plone/1/README.md
@@ -9,4 +9,4 @@ Just create and launch the stack.
 
 After that you can login with the regular user/password combination admin/admin.
 
-For usage see [Plone documentation site](http://docs.plone.org/5/en/).
+For more information on how to configure and use Plone visit [the official Plone 5 documentation site](http://docs.plone.org/5/en/).

--- a/templates/plone/1/docker-compose.yml
+++ b/templates/plone/1/docker-compose.yml
@@ -10,7 +10,7 @@ zeoserver:
   command: ["zeoserver"]
 
 plone:
-  image: plone:${version}
+  image: plone:5.0
   labels:
     io.rancher.scheduler.affinity:host_label: ${host_label}
     io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.community.plone=true

--- a/templates/plone/1/docker-compose.yml
+++ b/templates/plone/1/docker-compose.yml
@@ -1,5 +1,5 @@
 zeoserver:
-  image: plone:4.3
+  image: plone:5.0
   labels:
     io.rancher.scheduler.affinity:host_label: ${host_label}
     io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.community.plone=true

--- a/templates/plone/1/rancher-compose.yml
+++ b/templates/plone/1/rancher-compose.yml
@@ -1,6 +1,6 @@
 .catalog:
   name: "Plone"
-  version: "4.3-rancher1"
+  version: "5.0-rancher1"
   description: |
     Plone CMS
   uuid: plone-1


### PR DESCRIPTION
I created two distinct templates for Plone 4.3 and Plone 5.0 instead of being a question in the rancher-compose. This is more in line with rancher templates versions and gives the ability to upgrade properly between versions. Already discussed and reviewed by maintainer @avoinea. I also made some pointer in the READMEs to the plone documentation site.

 