### PR TITLE
Updated Prometheus catalog entry, 1.2 compatible

### DIFF
--- a/templates/Prometheus/3/README.md
+++ b/templates/Prometheus/3/README.md
@@ -1,0 +1,25 @@
+# Prometheus
+
+### Info:
+
+This template deploys a collection of containers based upon the technologies below, once deployed you should have a monitoring platform capable of querying all aspects of your environment with some nice pre-built dashboards. 
+In this deployment the following technologies are utilised to make this as useful as possible.
+* **Prometheus** - Used to scrape and store metrics from our data sources. (https://github.com/prometheus/prometheus)
+* **Prometheus Node Exporter** - Gets host level metrics and exposes them to Prometheus. (https://github.com/prometheus/node_exporter)
+* **cadvisor** - Deploys and Exposes the cadvsior stats used by Rancher's agent container, to Prometheus. (https://github.com/google/cadvisor)
+* **Grafana** - Used to visualise the data from Prometheus and InfluxDB. (https://github.com/grafana/grafana/)
+* **InfluxDB** - Used as database for storing rancher server metrics that rancher exports via the graphite connector. (https://github.com/influxdata/influxdb)
+* **Prometheus Rancher Exporter** - Allows Prometheus to access the Rancher API and return the status of any stack or service in the rancher environment associated with the API key used.(https://github.com/infinityworksltd/prometheus-rancher-exporter/)
+
+To get the full compliment of metrics available,you need to configure the Rancher `graphite.host` address. This can be done automatically when you deploy the template by choosing the option below, for more information or how to do this change manually,see the following [guide](https://github.com/infinityworksltd/Guide_Rancher_Monitoring)
+
+All components in this stack are open source tools available in the community. All this template does is to bound them together in an easy to use package.
+I expect most people who find this useful will make use of this as a starting point and develop it further around their own needs.
+ 
+## Deployment:
+* Select Prometheus from the community catalog.
+* Click deploy.
+
+## Usage
+* Grafana will now be available on, running on port 3000. I've added a number of dashboards to help get you started. Authentication is with the default `admin/admin`.
+* Prometheus will now be available, running on port 9090. Have a play around with some of the data. For more information on Prometheus - https://prometheus.io/docs/introduction/overview/

--- a/templates/Prometheus/3/docker-compose.yml
+++ b/templates/Prometheus/3/docker-compose.yml
@@ -1,0 +1,77 @@
+cadvisor:
+  labels:
+    io.rancher.scheduler.global: 'true'
+  tty: true
+  image: google/cadvisor:latest
+  stdin_open: true
+  volumes:
+    - "/:/rootfs:ro"
+    - "/var/run:/var/run:rw"
+    - "/sys:/sys:ro"
+    - "/var/lib/docker/:/var/lib/docker:ro"
+
+node-exporter:
+  labels:
+    io.rancher.scheduler.global: 'true'
+  tty: true
+  image: prom/node-exporter:latest
+  stdin_open: true
+
+prom-conf:
+    tty: true
+    image: infinityworks/prom-conf:16
+    volumes:
+      - /etc/prom-conf/
+    net: none
+
+prometheus:
+    tty: true
+    image: prom/prometheus:v1.3.1
+    command: -alertmanager.url=http://alertmanager:9093 -config.file=/etc/prom-conf/prometheus.yml -storage.local.path=/prometheus -web.console.libraries=/etc/prometheus/console_libraries -web.console.templates=/etc/prometheus/consoles
+    ports:
+      - 9090:9090
+    labels:
+      io.rancher.sidekicks: prom-conf
+    volumes_from:
+       - prom-conf
+    links:
+      - cadvisor:cadvisor
+      - node-exporter:node-exporter
+      - prometheus-rancher-exporter:prometheus-rancher-exporter
+
+influxdb:
+  image: tutum/influxdb:0.10
+  ports:
+    - 2003:2003
+  environment:
+    - PRE_CREATE_DB=grafana;prometheus;rancher
+    - GRAPHITE_DB=rancher
+    - GRAPHITE_BINDING=:2003
+
+graf-db:
+    tty: true
+    image: infinityworks/graf-db:09
+    command: cat
+    volumes:
+      - /var/lib/grafana/
+    net: none
+
+grafana:
+    tty: true
+    image: grafana/grafana:3.0.1
+    ports:
+      - 3000:3000
+    labels:
+      io.rancher.sidekicks: graf-db
+    volumes_from:
+       - graf-db
+    links:
+      - prometheus:prometheus
+      - prometheus-rancher-exporter:prometheus-rancher-exporter
+
+prometheus-rancher-exporter:
+    tty: true
+    labels:
+      io.rancher.container.create_agent: true
+      io.rancher.container.agent.role: environment
+    image: infinityworks/prometheus-rancher-exporter:10

--- a/templates/Prometheus/3/rancher-compose.yml
+++ b/templates/Prometheus/3/rancher-compose.yml
@@ -1,0 +1,53 @@
+.catalog:
+  name: "Prometheus"
+  version: "2.0.0"
+  description: "Prometheus Monitoring Solution"
+  uuid: prometheus-2
+  minimum_rancher_version: v1.1.99
+  questions:
+
+node-exporter:
+  upgrade_strategy:
+    start_first: true
+
+prometheus:
+  scale: 1
+  health_check:
+    port: 9090
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+influxdb:
+  scale: 1
+  health_check:
+    port: 8086
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+grafana:
+  scale: 1
+  health_check:
+    port: 3000
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+prometheus-rancher-exporter:
+  scale: 1
+  upgrade_strategy:
+    start_first: true
+  health_check:
+    port: 9010
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000

--- a/templates/Prometheus/config.yml
+++ b/templates/Prometheus/config.yml
@@ -1,5 +1,5 @@
 name: Prometheus
 description: |
   Prometheus and friends, auto-discovering monitoring solution for Rancher deployments.
-version: 1.3.0
+version: 2.0.0
 category: Monitoring


### PR DESCRIPTION
Ready for review, tested on Rancher 1.2. 

This sees us replace 'ranch-eye' with cadvisor following it's removal from the agent, it also sees us use the new 1.2 compatible Rancher Exporter.