### PR TITLE
Added cloud9 templates for catlle and k8s

### DIFF
--- a/kubernetes-templates/cloud9/0/README.md
+++ b/kubernetes-templates/cloud9/0/README.md
@@ -1,0 +1,23 @@
+# Cloud9 (Experimental)
+
+### Info:
+
+ This template deploys a cloud9 sdk.
+ 
+ 
+### Usage:
+
+ Select cloud9 from catalog. 
+
+ Change the following cloud9 default parameters, if you need:
+
+- cloud9_user=test			# Basic auth user
+- cloud9_pass=test1234		# Basic auth password
+- cloud9_port=8080			# Port to listen
+- cloud9_repo="" 			# Optional: Git repo to sync in your environment
+- cloud9_domain=dev.local 	# Ingress service domain
+
+ Click deploy.
+ 
+ Cloud9 can now be accessed over the Rancher network. 
+

--- a/kubernetes-templates/cloud9/0/cloud9-sdk-ingress.yml
+++ b/kubernetes-templates/cloud9/0/cloud9-sdk-ingress.yml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ${cloud9_name}
+  namespace: ${cloud9_namespace}
+spec:
+  rules:
+  - host: ${cloud9_name}.${cloud9_domain}
+    http:
+      paths:
+      - backend:
+          serviceName: ${cloud9_name}
+          servicePort: ${cloud9_port}

--- a/kubernetes-templates/cloud9/0/cloud9-sdk-rc.yml
+++ b/kubernetes-templates/cloud9/0/cloud9-sdk-rc.yml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ReplicationController
+metadata: 
+  name: "${cloud9_name}"
+  namespace: "${cloud9_namespace}"
+  labels:
+    name: "${cloud9_name}"
+spec:
+  replicas: 1
+  selector:
+    name: "${cloud9_name}"
+  template:
+    metadata: 
+      labels:
+        name: "${cloud9_name}"
+      annotations:
+    spec:
+      containers:
+        - name: "cloud9-sdk"
+          image: "rawmind/cloud9-sdk:0.3.0-2"
+          env:
+            - name: GIT_REPO
+              value: "${cloud9_repo}"
+          volumeMounts:
+            - mountPath: "/var/run/docker.sock"
+              name: "docker-socket"
+            - mountPath: "/bin/docker"
+              name: "docker-exec"
+            - mountPath: "/workspace"
+              name: "cloud9-data"
+          ports:
+            - containerPort: ${cloud9_port}
+              name: "cloud9-port"
+              protocol: "TCP"
+          args:
+            - --listen 0.0.0.0 
+            - --port ${cloud9_port} 
+            - -w /workspace 
+            - --collab 
+            - --auth ${cloud9_user}:${cloud9_pass}
+          imagePullPolicy: "IfNotPresent"
+      restartPolicy: "Always"
+      volumes:
+        - name: "cloud9-data"
+          emptyDir: {}
+        - name: "docker-socket"
+          hostPath:
+            path: "/var/run/docker.sock"
+        - name: "docker-exec" 
+          hostPath:
+            path: "/usr/local/bin/docker"

--- a/kubernetes-templates/cloud9/0/cloud9-sdk-service.yml
+++ b/kubernetes-templates/cloud9/0/cloud9-sdk-service.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "${cloud9_name}"
+  namespace: "${cloud9_namespace}"
+  labels:
+    name: "${cloud9_name}"
+spec:
+  ports:
+  - port: ${cloud9_port}
+    targetPort: ${cloud9_port}
+    name: "cloud9-port"
+    protocol: "TCP"
+  selector:
+    name: "${cloud9_name}"

--- a/kubernetes-templates/cloud9/0/rancher-compose.yml
+++ b/kubernetes-templates/cloud9/0/rancher-compose.yml
@@ -1,0 +1,63 @@
+.catalog:
+  name: Cloud9
+  description: |
+    (Experimental) Cloud 9 SDK 
+  version: 3.0-k8s1
+  minimum_rancher_version: v1.0.0
+  maintainer: "Raul Sanchez <rawmind@gmail.com>"
+  uuid: cloud9-0
+  questions:
+    - variable: "cloud9_name"
+      description: "Name of cloud9 rc and service."
+      label: "K8s rc name:"
+      required: true
+      default: "cloud9"
+      type: "string"
+    - variable: "cloud9_namespace"
+      description: "Name of cloud9 namespace."
+      label: "K8s namespace:"
+      required: true
+      default: "default"
+      type: "string"
+    - variable: "cloud9_user"
+      description: |
+        Username. 
+      label: "Username:"
+      default: "test"
+      required: true
+      type: "string"
+    - variable: "cloud9_pass"
+      description: |
+        Password. 
+      label: "Password:"
+      default: "test1234"
+      required: true
+      type: "string"
+    - variable: "cloud9_port"
+      description: "Port to listen"
+      label: "Port:"
+      required: true
+      default: "8080"
+      type: "int"
+    - variable: "cloud9_repo"
+      description: "Git repo to sync"
+      label: "Git repo:"
+      required: false
+      default: ""
+      type: "string"
+    - variable: "cloud9_domain"
+      description: "Ingress service domain"
+      label: "Ingress domain:"
+      required: true
+      default: "dev.local"
+      type: "string"
+cloud9-sdk:
+  scale: 1
+  retain_ip: true
+  health_check:
+    port: ${cloud9_port}
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000

--- a/kubernetes-templates/cloud9/catalogIcon-cloud9-sdk.svg
+++ b/kubernetes-templates/cloud9/catalogIcon-cloud9-sdk.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="550"
+   height="347.76266"
+   viewBox="0 0 550 347.76267"
+   id="svg2"
+   xml:space="preserve"><metadata
+     id="metadata8"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs6"><clipPath
+       id="clipPath18"><path
+         d="M 0,560 H 960 V 0 H 0 z"
+         id="path16" /></clipPath></defs><g
+     transform="matrix(1.3333333,0,0,-1.3333333,278.34858,94.208134)"
+     id="g44"><path
+       d="m 0,0 c -7.084,0 -10.949,-9.35 -10.949,-17.377 0,-13.363 6.012,-34.483 18.679,-34.483 6.669,0 10.107,7.484 10.107,14.974 C 17.837,-25.663 12.467,0 0,0"
+       id="path46"
+       style="fill:#2C91DE;fill-opacity:1;fill-rule:evenodd;stroke:none" /></g><g
+     transform="matrix(1.3329076,0,0,-1.3333333,333.50647,238.21199)"
+     id="g48"><path
+       d="m 0,0 c -6.447,-10.964 -29.663,-45.45 -41.044,-45.45 -6.024,0 -27.937,10.953 -27.937,18.698 0,2.679 3.004,5.622 4.723,6.694 10.105,6.691 21.282,25.932 21.282,36.629 0,3.481 -1.933,5.086 -4.52,5.086 -3.437,0 -6.873,-0.804 -10.314,-0.804 -31.152,0 -45.553,33.687 -45.553,64.163 0,42.782 33.308,62.294 63.607,62.294 32.234,0 64.898,-19.786 64.898,-64.97 C 25.142,51.596 14.392,24.331 0,0 m 138.134,69.91 c -21.976,21.98 -53.225,29.038 -81.151,21.186 -4.724,49.139 -46.127,87.563 -96.504,87.563 -46.524,0 -85.402,-32.776 -94.786,-76.496 -30.654,9.794 -65.578,2.531 -89.895,-21.786 -34.677,-34.679 -34.677,-90.898 0,-125.572 28.763,-28.773 70.722,-36.968 92.593,-36.968 0,0 3.377,0.023 10.388,0.023 h 159.46 c 33.017,-0.213 68.704,3.578 99.895,34.762 32.384,32.384 32.384,84.903 0,117.288"
+       id="path50"
+       style="fill:#2C91DE;fill-opacity:1;fill-rule:evenodd;stroke:none" /></g></svg>

--- a/kubernetes-templates/cloud9/config.yml
+++ b/kubernetes-templates/cloud9/config.yml
@@ -1,0 +1,8 @@
+name: Cloud9
+description: |
+  (Experimental) Cloud 9 SDK 
+version: 3.0-k8s1
+category: Agile
+maintainer: "Raul Sanchez <rawmind@gmail.com>"
+license: 
+projectURL: https://github.com/rawmind0/cloud9-sdk

--- a/templates/cloud9/0/README.md
+++ b/templates/cloud9/0/README.md
@@ -1,0 +1,24 @@
+# Cloud9 (Experimental)
+
+### Info:
+
+ This template deploys a cloud9 sdk.
+ 
+ 
+### Usage:
+
+ Select cloud9 from catalog. 
+
+ Change the following cloud9 default parameters, if you need:
+
+- cloud9_user=test			# Basic auth user
+- cloud9_pass=test1234		# Basic auth password
+- cloud9_port=8080			# Port to listen
+- cloud9_repo="" 			# Optional: Git repo to sync in your environment
+- cloud9_publish=stack		# Publish the service in traefik
+- cloud9_domain=dev.local 	# Publish service domain
+
+ Click deploy.
+ 
+ Cloud9 can now be accessed over the Rancher network. 
+

--- a/templates/cloud9/0/docker-compose.yml
+++ b/templates/cloud9/0/docker-compose.yml
@@ -1,0 +1,14 @@
+cloud9-sdk:
+  command: "--listen 0.0.0.0 --port ${cloud9_port} -w /workspace --collab --auth ${cloud9_user}:${cloud9_pass}"
+  image: "rawmind/cloud9-sdk:0.3.0-2"
+  restart: "always"
+  volumes:
+    - "/var/run/docker.sock:/var/run/docker.sock"
+    - "/usr/local/bin/docker:/bin/docker"
+    - "/workspace"
+  environment:
+    GIT_REPO: ${cloud9_repo}
+  labels:
+    traefik.domain: ${cloud9_domain}
+    traefik.port: ${cloud9_port}
+    traefik.enable: ${cloud9_publish}

--- a/templates/cloud9/0/rancher-compose.yml
+++ b/templates/cloud9/0/rancher-compose.yml
@@ -1,0 +1,61 @@
+.catalog:
+  name: Cloud9
+  description: |
+    (Experimental) Cloud 9 SDK 
+  version: 3.0-rancher1
+  minimum_rancher_version: v1.0.0
+  maintainer: "Raul Sanchez <rawmind@gmail.com>"
+  uuid: cloud9-0
+  questions:
+    - variable: "cloud9_user"
+      description: |
+        Username. 
+      label: "Username:"
+      default: "test"
+      required: true
+      type: "string"
+    - variable: "cloud9_pass"
+      description: |
+        Password. 
+      label: "Password:"
+      default: "test1234"
+      required: true
+      type: "string"
+    - variable: "cloud9_port"
+      description: "Port to listen"
+      label: "Port:"
+      required: true
+      default: "8080"
+      type: "int"
+    - variable: "cloud9_repo"
+      description: "Git repo to sync"
+      label: "Git repo:"
+      required: false
+      default: ""
+      type: "string"
+    - variable: "cloud9_publish"
+      label: "Publish:"
+      description: "Publish service to traefik."
+      default: stack
+      required: true
+      type: enum
+      options:
+        - false
+        - true
+        - stack
+    - variable: "cloud9_domain"
+      description: "Publish service domain"
+      label: "Publish domain:"
+      required: true
+      default: "dev.local"
+      type: "string"
+cloud9-sdk:
+  scale: 1
+  retain_ip: true
+  health_check:
+    port: ${cloud9_port}
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000

--- a/templates/cloud9/catalogIcon-cloud9-sdk.svg
+++ b/templates/cloud9/catalogIcon-cloud9-sdk.svg
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="550"
+   height="347.76266"
+   viewBox="0 0 550 347.76267"
+   id="svg2"
+   xml:space="preserve"><metadata
+     id="metadata8"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs6"><clipPath
+       id="clipPath18"><path
+         d="M 0,560 H 960 V 0 H 0 z"
+         id="path16" /></clipPath></defs><g
+     transform="matrix(1.3333333,0,0,-1.3333333,278.34858,94.208134)"
+     id="g44"><path
+       d="m 0,0 c -7.084,0 -10.949,-9.35 -10.949,-17.377 0,-13.363 6.012,-34.483 18.679,-34.483 6.669,0 10.107,7.484 10.107,14.974 C 17.837,-25.663 12.467,0 0,0"
+       id="path46"
+       style="fill:#2C91DE;fill-opacity:1;fill-rule:evenodd;stroke:none" /></g><g
+     transform="matrix(1.3329076,0,0,-1.3333333,333.50647,238.21199)"
+     id="g48"><path
+       d="m 0,0 c -6.447,-10.964 -29.663,-45.45 -41.044,-45.45 -6.024,0 -27.937,10.953 -27.937,18.698 0,2.679 3.004,5.622 4.723,6.694 10.105,6.691 21.282,25.932 21.282,36.629 0,3.481 -1.933,5.086 -4.52,5.086 -3.437,0 -6.873,-0.804 -10.314,-0.804 -31.152,0 -45.553,33.687 -45.553,64.163 0,42.782 33.308,62.294 63.607,62.294 32.234,0 64.898,-19.786 64.898,-64.97 C 25.142,51.596 14.392,24.331 0,0 m 138.134,69.91 c -21.976,21.98 -53.225,29.038 -81.151,21.186 -4.724,49.139 -46.127,87.563 -96.504,87.563 -46.524,0 -85.402,-32.776 -94.786,-76.496 -30.654,9.794 -65.578,2.531 -89.895,-21.786 -34.677,-34.679 -34.677,-90.898 0,-125.572 28.763,-28.773 70.722,-36.968 92.593,-36.968 0,0 3.377,0.023 10.388,0.023 h 159.46 c 33.017,-0.213 68.704,3.578 99.895,34.762 32.384,32.384 32.384,84.903 0,117.288"
+       id="path50"
+       style="fill:#2C91DE;fill-opacity:1;fill-rule:evenodd;stroke:none" /></g></svg>

--- a/templates/cloud9/config.yml
+++ b/templates/cloud9/config.yml
@@ -1,0 +1,8 @@
+name: Cloud9
+description: |
+  (Experimental) Cloud 9 SDK 
+version: 3.0-rancher1
+category: Agile
+maintainer: "Raul Sanchez <rawmind@gmail.com>"
+license: 
+projectURL: https://github.com/rawmind0/cloud9-sdk


### PR DESCRIPTION
Added catalog templates to deploy cloud9 sdk, to share a dev environment.

It could be auto published throught traefik in cattle and ingress in k8s.