### PR TITLE
Updating vultr driver to 1.2.0

### DIFF
--- a/machine-templates/vultr/5/checksum
+++ b/machine-templates/vultr/5/checksum
@@ -1,0 +1,1 @@
+1b1efcfe48edb7ab71d6c1bee46f8a99

--- a/machine-templates/vultr/5/rancher-compose.yml
+++ b/machine-templates/vultr/5/rancher-compose.yml
@@ -1,0 +1,3 @@
+.catalog:
+  name: "vultr"
+  version: "1.2.0"

--- a/machine-templates/vultr/5/url
+++ b/machine-templates/vultr/5/url
@@ -1,0 +1,1 @@
+https://github.com/janeczku/docker-machine-vultr/releases/download/v1.2.0/docker-machine-driver-vultr-v1.2.0-linux-amd64.tar.gz

--- a/machine-templates/vultr/config.yml
+++ b/machine-templates/vultr/config.yml
@@ -1,2 +1,2 @@
 name: vultr
-version: "1.1.0"
+version: "1.2.0"


### PR DESCRIPTION
This pulls in some fixes including https://github.com/janeczku/docker-machine-vultr/issues/18

Release listed here: https://github.com/janeczku/docker-machine-vultr/releases/tag/v1.2.0

