### PR TITLE
Update Wordpress template

### DIFF
--- a/templates/wordpress/1/docker-compose.yml
+++ b/templates/wordpress/1/docker-compose.yml
@@ -1,0 +1,11 @@
+wordpress:
+  image: wordpress
+  links:
+    - db:mysql
+  ports:
+    - ${public_port}:80
+
+db:
+  image: mariadb
+  environment:
+    MYSQL_ROOT_PASSWORD: example

--- a/templates/wordpress/1/docker-compose.yml
+++ b/templates/wordpress/1/docker-compose.yml
@@ -6,6 +6,8 @@ wordpress:
     - ${public_port}:80
 
 db:
-  image: mariadb
+  image: webhippie/mariadb
   environment:
-    MYSQL_ROOT_PASSWORD: example
+    MYSQL_ROOT_PASSWORD: ${mysql_root_password}
+    MARIADB_ROOT_PASSWORD: ${mysql_root_password}
+    MARIADB_INNODB_BUFFER_POOL_SIZE: ${innodb_buffer_pool_size}

--- a/templates/wordpress/1/rancher-compose.yml
+++ b/templates/wordpress/1/rancher-compose.yml
@@ -1,0 +1,16 @@
+.catalog:
+  name: "Wordpress"
+  version: "v0.1-educaas1"
+  description: "Blog tool, publishing platform and CMS"
+  uuid: Wordpress-0
+  minimum_rancher_version: v0.51.0
+  questions:    
+    - variable: public_port
+      description: "public port to access the wordpress site"
+      label: "Public Port"
+      required: true
+      default: "80"
+      type: "int"
+
+
+wordpress:

--- a/templates/wordpress/1/rancher-compose.yml
+++ b/templates/wordpress/1/rancher-compose.yml
@@ -1,16 +1,27 @@
 .catalog:
   name: "Wordpress"
-  version: "v0.1-educaas1"
+  version: "v0.2"
   description: "Blog tool, publishing platform and CMS"
-  uuid: Wordpress-0
   minimum_rancher_version: v0.51.0
-  questions:    
-    - variable: public_port
-      description: "public port to access the wordpress site"
+  questions:
+    - variable: "public_port"
+      description: "Public port to access the Wordpress site"
       label: "Public Port"
       required: true
       default: "80"
       type: "int"
-
-
-wordpress:
+    - variable: "mysql_root_password"
+      description: "Choose the MySQL root password"
+      label: "MySQL root password"
+      required: true
+      default: "wordpress"
+      type: "string"
+    - variable: "innodb_buffer_pool_size"
+      description: "Optionally tweak the InnoDB buffer pool size configuration setting"
+      label: "MySQL InnoDB Buffer Pool Size"
+      required: true
+      default: "8M"
+      type: "string"
+db:
+  scale: 1
+  retain_ip: true

--- a/templates/wordpress/config.yml
+++ b/templates/wordpress/config.yml
@@ -1,5 +1,5 @@
 name: Wordpress
 description: |
   Blog tool, publishing platform and CMS
-version: v0.1-educaas1
+version: v0.2
 category: Blogging


### PR DESCRIPTION
- Fixes issue running on smaller VMs due to DB using a lot of memory (was ~ 256MB, now  ~ 128 MB).
- Use `retain_IP` for the db
- Allow to configure `innodb_buffer_pool_size`