### PR TITLE
Fix logmatic-docker entrypoint

### DIFF
--- a/templates/logmatic/0/docker-compose.yml
+++ b/templates/logmatic/0/docker-compose.yml
@@ -1,6 +1,6 @@
 logmatic-agent:
   image: logmatic/logmatic-docker
-  entrypoint: /usr/src/app/index.js
+  entrypoint: python /app/main.py
   command: ${logmatic_key} ${opts_args}
   restart: always
   volumes:


### PR DESCRIPTION
1.0 (deprecated): NodeJS docker client, not compatible with the Logmatic.io integration.
1.2 (latest): use python.