### PR TITLE
Update Datadog template to 1.1.0-11.0.5110

### DIFF
--- a/templates/datadog/0/rancher-compose.yml
+++ b/templates/datadog/0/rancher-compose.yml
@@ -3,6 +3,7 @@
   version: "11.0.563-rancher1"
   description: "Datadog Agent and DogStatsD"
   minimum_rancher_version: v0.46.0
+  maximum_rancher_version: v1.1.99
   questions:
     - variable: "api_key"
       label: "DataDog Api Key"

--- a/templates/datadog/1/rancher-compose.yml
+++ b/templates/datadog/1/rancher-compose.yml
@@ -3,6 +3,7 @@
   version: "11.0.570-rancher1"
   description: "Real-time performance tracking and visualization of your container-based application deployment"
   minimum_rancher_version: v0.46.0
+  maximum_rancher_version: v1.1.99
   questions:
     - variable: "api_key"
       label: "DataDog Api Key"

--- a/templates/datadog/2/rancher-compose.yml
+++ b/templates/datadog/2/rancher-compose.yml
@@ -3,6 +3,7 @@
   version: 11.0.580-rancher1
   description: Real-time performance tracking and visualization of your container-based application deployment
   minimum_rancher_version: v0.46.0
+  maximum_rancher_version: v1.1.99
   questions:
     - variable: api_key
       label: Datadog Api Key

--- a/templates/datadog/3/rancher-compose.yml
+++ b/templates/datadog/3/rancher-compose.yml
@@ -3,6 +3,7 @@
   version: "11.1.580-rancher1"
   description: "Real-time performance tracking and visualization of your container-based application deployment"
   minimum_rancher_version: v0.46.0
+  maximum_rancher_version: v1.1.99
   questions:
     - variable: "api_key"
       label: "DataDog Api Key"

--- a/templates/datadog/4/rancher-compose.yml
+++ b/templates/datadog/4/rancher-compose.yml
@@ -3,6 +3,7 @@
   version: "11.3.585-rancher1"
   description: "Real-time performance tracking and visualization of your container-based application deployment"
   minimum_rancher_version: v0.46.0
+  maximum_rancher_version: v1.1.99
   questions:
     - variable: "api_key"
       label: "DataDog Api Key"

--- a/templates/datadog/5/README.md
+++ b/templates/datadog/5/README.md
@@ -7,7 +7,7 @@ This template deploys a [Datadog](https://www.datadoghq.com/) agent stack consis
 * Service labels can be exported as Datadog metric tags
 
 ## Service Discovery
-**Note**: Service discovery is currently not working in Rancher 1.2 and up due to the switch to CNI networking.
+**Note**: Service discovery templates that contain the `%%host%%` placeholder are currently not working in Rancher 1.2 and up due to the switch to CNI networking.
 
 Please refer to the Datadog documentation [here](http://docs.datadoghq.com/guides/servicediscovery/) to learn how to provide configuration templates for Service Discovery in etcd or Consul.
 

--- a/templates/datadog/5/README.md
+++ b/templates/datadog/5/README.md
@@ -1,0 +1,16 @@
+# DataDog Agent
+
+This template deploys a [DataDog](https://www.datadoghq.com/) agent stack consisting of the official [docker-dd-agent](https://www.github.com/Datadog/docker-dd-agent) image and a configuration sidekick that provides closer integration with Rancher:
+
+* Hosts in Datadog are named correctly
+* Host labels can be exported as DataDog host tags
+* Service labels can be exported as DataDog metric tags
+
+## Service Discovery
+Please refer to the Datadog documentation [here](http://docs.datadoghq.com/guides/servicediscovery/) to learn how to provide configuration templates for Service Discovery in etcd or Consul.
+
+## Changelog
+
+**11.3.585**
+
+* Support for specifying connection options for Consul backends (ACL token, scheme, SSL certificate verification)

--- a/templates/datadog/5/README.md
+++ b/templates/datadog/5/README.md
@@ -1,16 +1,25 @@
-# DataDog Agent
+# Datadog agent
 
-This template deploys a [DataDog](https://www.datadoghq.com/) agent stack consisting of the official [docker-dd-agent](https://www.github.com/Datadog/docker-dd-agent) image and a configuration sidekick that provides closer integration with Rancher:
+This template deploys a [Datadog](https://www.datadoghq.com/) agent stack consisting of the official [docker-dd-agent](https://www.github.com/Datadog/docker-dd-agent) image and a configuration sidekick that provides closer integration with Rancher:
 
 * Hosts in Datadog are named correctly
-* Host labels can be exported as DataDog host tags
-* Service labels can be exported as DataDog metric tags
+* Host labels can be exported as Datadog host tags
+* Service labels can be exported as Datadog metric tags
 
 ## Service Discovery
+**Note**: Service discovery is currently not working in Rancher 1.2 and up due to the switch to CNI networking.
+
 Please refer to the Datadog documentation [here](http://docs.datadoghq.com/guides/servicediscovery/) to learn how to provide configuration templates for Service Discovery in etcd or Consul.
 
 ## Changelog
 
-**11.3.585**
+**1.1.0-11.0.5110**
 
-* Support for specifying connection options for Consul backends (ACL token, scheme, SSL certificate verification)
+New versioning scheme: `<TemplateVersion>-<DatadogImageVersion>`
+
+* DEPRECATED: DogStatsd standalone mode
+* NEW: Configure global host tags
+* NEW: Configure custom log verbosity
+* NEW: Enable collection of AWS EC2 custom tags
+* NEW: Support for Amazon Linux AMIs
+* NEW: Enable Datadog trace agent

--- a/templates/datadog/5/docker-compose.yml
+++ b/templates/datadog/5/docker-compose.yml
@@ -1,5 +1,5 @@
 datadog-init:
-  image: janeczku/datadog-rancher-init:v2.2.3
+  image: janeczku/datadog-rancher-init:v2.2.4
   net: none
   command: /bin/true
   volumes:
@@ -8,7 +8,7 @@ datadog-init:
     io.rancher.container.start_once: 'true'
     io.rancher.container.pull_image: always
 datadog-agent:
-  image: datadog/docker-dd-agent:11.3.585
+  image: datadog/docker-dd-agent:11.0.5110
   entrypoint: /opt/rancher/entrypoint-wrapper.py
   command:
     - supervisord
@@ -17,12 +17,16 @@ datadog-agent:
     - /etc/dd-agent/supervisor.conf
   restart: always
   environment:
+    # Evaluated by datadog-agent image
     API_KEY: ${api_key}
     SD_BACKEND_HOST: ${sd_backend_host}
     SD_BACKEND_PORT: ${sd_backend_port}
     SD_TEMPLATE_DIR: ${sd_template_dir}
     STATSD_METRIC_NAMESPACE: ${statsd_namespace}
-    DD_STATSD_STANDALONE: "${statsd_standalone}"
+    DD_APM_ENABLED: ${dd_apm_enabled}
+    EC2_TAGS: ${dd_ec2_tags}
+    DD_LOG_LEVEL: ${dd_log_level}
+    # Evaluated by datadog-init script
     DD_HOST_LABELS: ${host_labels}
     DD_CONTAINER_LABELS: ${service_labels}
     DD_SERVICE_DISCOVERY: ${service_discovery}
@@ -30,10 +34,12 @@ datadog-agent:
     DD_CONSUL_TOKEN: ${dd_consul_token}
     DD_CONSUL_SCHEME: ${dd_consul_scheme}
     DD_CONSUL_VERIFY: ${dd_consul_verify}
+    DD_METADATA_HOSTNAME: rancher-metadata
+    TAGS: ${host_tags}
   volumes:
     - /var/run/docker.sock:/var/run/docker.sock
     - /proc/:/host/proc/:ro
-    - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+    - ${cgroups_location}:/host/sys/fs/cgroup:ro
   volumes_from:
     - datadog-init
   labels:

--- a/templates/datadog/5/docker-compose.yml
+++ b/templates/datadog/5/docker-compose.yml
@@ -1,0 +1,41 @@
+datadog-init:
+  image: janeczku/datadog-rancher-init:v2.2.3
+  net: none
+  command: /bin/true
+  volumes:
+    - /opt/rancher
+  labels:
+    io.rancher.container.start_once: 'true'
+    io.rancher.container.pull_image: always
+datadog-agent:
+  image: datadog/docker-dd-agent:11.3.585
+  entrypoint: /opt/rancher/entrypoint-wrapper.py
+  command:
+    - supervisord
+    - -n
+    - -c
+    - /etc/dd-agent/supervisor.conf
+  restart: always
+  environment:
+    API_KEY: ${api_key}
+    SD_BACKEND_HOST: ${sd_backend_host}
+    SD_BACKEND_PORT: ${sd_backend_port}
+    SD_TEMPLATE_DIR: ${sd_template_dir}
+    STATSD_METRIC_NAMESPACE: ${statsd_namespace}
+    DD_STATSD_STANDALONE: "${statsd_standalone}"
+    DD_HOST_LABELS: ${host_labels}
+    DD_CONTAINER_LABELS: ${service_labels}
+    DD_SERVICE_DISCOVERY: ${service_discovery}
+    DD_SD_CONFIG_BACKEND: ${sd_config_backend}
+    DD_CONSUL_TOKEN: ${dd_consul_token}
+    DD_CONSUL_SCHEME: ${dd_consul_scheme}
+    DD_CONSUL_VERIFY: ${dd_consul_verify}
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /proc/:/host/proc/:ro
+    - /sys/fs/cgroup/:/host/sys/fs/cgroup:ro
+  volumes_from:
+    - datadog-init
+  labels:
+    io.rancher.scheduler.global: "${global_service}"
+    io.rancher.sidekicks: 'datadog-init'

--- a/templates/datadog/5/rancher-compose.yml
+++ b/templates/datadog/5/rancher-compose.yml
@@ -1,0 +1,107 @@
+.catalog:
+  name: "DataDog"
+  version: "11.3.585-rancher1"
+  description: "Real-time performance tracking and visualization of your container-based application deployment"
+  minimum_rancher_version: v0.46.0
+  questions:
+    - variable: "api_key"
+      label: "DataDog Api Key"
+      description: |
+        Enter your DataDog API key.
+      required: true
+      type: "string"
+    - variable: "global_service"
+      label: "Global Service"
+      description: |
+        Enable this option to run a DataDog agent container on every host in the environment.
+      required: true
+      type: "boolean"
+      default: true
+    - variable: "host_labels"
+      label: "Export Host Labels as Tags"
+      description: |
+        Comma delimited list of host labels to export as DataDog host tags, e.g. 'region,zone'.
+      required: false
+      type: "string"
+    - variable: "service_labels"
+      label: "Export Service Labels as Tags"
+      description: |
+        Comma delimited list of service labels to export as DataDog metric tags.
+        'io.rancher.stack.name' and 'io.rancher.stack_service.name' are exported by default.
+      required: false
+      type: "string"
+    - variable: "service_discovery"
+      label: "Enable Service Discovery"
+      description: |
+        Collect metrics from supported applications running in Docker containers.
+      required: true
+      type: "boolean"
+      default: false
+    - variable: sd_config_backend
+      label: Service Discovery Configuration Backend
+      description: |
+        Choose a key/value store to use for looking up application configuration templates.
+        If none is provided only auto config templates will be used.
+      required: true
+      type: enum
+      default: none
+      options:
+        - none
+        - etcd
+        - consul
+    - variable: "sd_backend_host"
+      label: "Configuration Backend Host"
+      description: |
+        IP address or DNS name to use to connect to the configuration backend.
+      required: false
+      type: "string"
+    - variable: "sd_backend_port"
+      label: "Configuration Backend Port"
+      description: |
+        Port to use to connect to the configuration backend.
+      required: false
+      type: "int"
+    - variable: "sd_template_dir"
+      label: "Configuration Backend Template Path"
+      description: |
+        Specify a custom path where the agent should look for configuration templates in the backend.
+        The default is '/datadog/check_configs'.
+      required: false
+      type: "string"
+    - variable: "dd_consul_scheme"
+      label: "Consul Connection Scheme"
+      description: |
+        Scheme to use for requests to a Consul backend.
+      required: false
+      type: enum
+      default: http
+      options:
+        - http
+        - https
+    - variable: "dd_consul_verify"
+      label: "Verify Consul SSL Certificate"
+      description: |
+        Whether to verify the SSL certificate for HTTPS requests to a Consul backend.
+      required: false
+      type: "boolean"
+      default: true
+    - variable: "dd_consul_token"
+      label: "Consul ACL Token"
+      description: |
+        If the Consul backend uses ACL, specify a token granting read access to the configuration templates.
+      required: false
+      type: "string"
+    - variable: "statsd_standalone"
+      label: "Run Standalone DogStatsD"
+      description: |
+        Enable this option to run just the DogStatsD service without the full agent.
+        Should be used with the Global Service option set 'False'.
+      required: true
+      type: "boolean"
+      default: false
+    - variable: "statsd_namespace"
+      label: "StatsD Metric Namespace"
+      description: |
+        Optional namespace for aggregated StatsD metrics.
+      required: false
+      type: "string"

--- a/templates/datadog/5/rancher-compose.yml
+++ b/templates/datadog/5/rancher-compose.yml
@@ -1,35 +1,65 @@
 .catalog:
-  name: "DataDog"
-  version: "11.3.585-rancher1"
+  name: "Datadog"
+  version: "1.1.0-11.0.5110"
   description: "Real-time performance tracking and visualization of your container-based application deployment"
-  minimum_rancher_version: v0.46.0
+  minimum_rancher_version: v1.2.0
   questions:
     - variable: "api_key"
-      label: "DataDog Api Key"
+      label: "Datadog API Key"
       description: |
-        Enter your DataDog API key.
+        Enter your Datadog API key.
       required: true
       type: "string"
     - variable: "global_service"
       label: "Global Service"
       description: |
-        Enable this option to run a DataDog agent container on every host in the environment.
+        Enable this option to run a Datadog agent container on every host in the environment.
       required: true
       type: "boolean"
       default: true
     - variable: "host_labels"
       label: "Export Host Labels as Tags"
       description: |
-        Comma delimited list of host labels to export as DataDog host tags, e.g. 'region,zone'.
+        Comma delimited list of host labels to export as Datadog host tags, e.g. 'region,zone'.
       required: false
       type: "string"
     - variable: "service_labels"
       label: "Export Service Labels as Tags"
       description: |
-        Comma delimited list of service labels to export as DataDog metric tags.
+        Comma delimited list of service labels to export as Datadog metric tags.
         'io.rancher.stack.name' and 'io.rancher.stack_service.name' are exported by default.
       required: false
       type: "string"
+    - variable: "host_tags"
+      label: "Global Host Tags"
+      description: |
+        Comma delimited list of host tags to apply to metrics, e.g. 'simple-tag-0,tag-key-1:tag-value-1'.
+      required: false
+      type: "string"
+    - variable: "dd_ec2_tags"
+      label: "Collect AWS EC2 Tags"
+      description: |
+        Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance).
+      required: true
+      type: "boolean"
+      default: false
+    - variable: cgroups_location
+      label: Cgroup directory location
+      description: |
+        Set this to '/cgroups/' if your hosts are running Amazon Linux AMIs.
+      required: true
+      type: enum
+      default: '/sys/fs/cgroup/'
+      options:
+        - '/sys/fs/cgroup/'
+        - '/cgroups/'
+    - variable: "dd_apm_enabled"
+      label: "Enable APM agent"
+      description: |
+        Enable the Datadog trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp.
+      required: true
+      type: "boolean"
+      default: false
     - variable: "service_discovery"
       label: "Enable Service Discovery"
       description: |
@@ -37,7 +67,7 @@
       required: true
       type: "boolean"
       default: false
-    - variable: sd_config_backend
+    - variable: "sd_config_backend"
       label: Service Discovery Configuration Backend
       description: |
         Choose a key/value store to use for looking up application configuration templates.
@@ -91,17 +121,22 @@
         If the Consul backend uses ACL, specify a token granting read access to the configuration templates.
       required: false
       type: "string"
-    - variable: "statsd_standalone"
-      label: "Run Standalone DogStatsD"
-      description: |
-        Enable this option to run just the DogStatsD service without the full agent.
-        Should be used with the Global Service option set 'False'.
-      required: true
-      type: "boolean"
-      default: false
     - variable: "statsd_namespace"
       label: "StatsD Metric Namespace"
       description: |
         Optional namespace for aggregated StatsD metrics.
       required: false
       type: "string"
+    - variable: "dd_log_level"
+      label: "Agent log level"
+      description: |
+        Set the logging verbosity of the Datadog agent.
+      required: false
+      type: enum
+      default: INFO
+      options:
+        - CRITICAL
+        - ERROR
+        - WARNING
+        - INFO
+        - DEBUG

--- a/templates/datadog/config.yml
+++ b/templates/datadog/config.yml
@@ -1,7 +1,7 @@
 name: Datadog
 description: |
   Real-time performance tracking and visualization of your container-based application deployment
-version: 11.3.585-rancher1
+version: 1.1.0-11.0.5110
 category: Monitoring
 maintainer: "Jan Bruder <jan@rancher.com>"
 license: The MIT License


### PR DESCRIPTION
This also disables previous versions of the template on Rancher v1.2.0 and up.