### PR TITLE
PostgreSQL fix: LB is set to HTTP protocol

### DIFF
--- a/templates/postgres/0/docker-compose.yml
+++ b/templates/postgres/0/docker-compose.yml
@@ -1,11 +1,9 @@
 version: '2'
 services:
   postgres-lb:
-    image: rancher/load-balancer-service
-    links:
-      - postgres
+    image: rancher/lb-service-haproxy
     ports:
-      - ${lb_port}:5432
+      - ${lb_port}
 
   postgres-data:
     image: busybox


### PR DESCRIPTION
Apparently this happens because of the legacy load balancer image.
Fixed by changing LB image to `rancher/lb-service-haproxy`.