### PR TITLE
Upgrade prometheus-rancher-exporter-rc to fix startup error in Rancher 1.3.4+

### DIFF
--- a/kubernetes-templates/Prometheus/1/README.md
+++ b/kubernetes-templates/Prometheus/1/README.md
@@ -1,0 +1,25 @@
+# Prometheus
+
+### Info:
+
+This template deploys a collection of containers based upon the technologies below, once deployed you should have a monitoring platform capable of querying all aspects of your environment with some nice pre-built dashboards. 
+In this deployment the following technologies are utilised to make this as useful as possible.
+* **Prometheus** - Used to scrape and store metrics from our data sources. (https://github.com/prometheus/prometheus)
+* **Prometheus Node Exporter** - Gets host level metrics and exposes them to Prometheus. (https://github.com/prometheus/node_exporter)
+* **cadvisor** - Deploys and Exposes the cadvsior stats used by Rancher's agent container, to Prometheus. (https://github.com/google/cadvisor)
+* **Grafana** - Used to visualise the data from Prometheus and InfluxDB. (https://github.com/grafana/grafana/)
+* **InfluxDB** - Used as database for storing rancher server metrics that rancher exports via the graphite connector. (https://github.com/influxdata/influxdb)
+* **Prometheus Rancher Exporter** - Allows Prometheus to access the Rancher API and return the status of any stack or service in the rancher environment associated with the API key used.(https://github.com/infinityworksltd/prometheus-rancher-exporter/)
+
+To get the full compliment of metrics available,you need to configure the Rancher `graphite.host` address. This can be done automatically when you deploy the template by choosing the option below, for more information or how to do this change manually,see the following [guide](https://github.com/infinityworksltd/Guide_Rancher_Monitoring)
+
+All components in this stack are open source tools available in the community. All this template does is to bound them together in an easy to use package.
+I expect most people who find this useful will make use of this as a starting point and develop it further around their own needs.
+ 
+## Deployment:
+* Select Prometheus from the community catalog.
+* Click deploy.
+
+## Usage
+* Grafana will now be available on, running on port 3000. I've added a number of dashboards to help get you started. Authentication is with the default `admin/admin`.
+* Prometheus will now be available, running on port 9090. Have a play around with some of the data. For more information on Prometheus - https://prometheus.io/docs/introduction/overview/

--- a/kubernetes-templates/Prometheus/1/grafana-rc.yml
+++ b/kubernetes-templates/Prometheus/1/grafana-rc.yml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: grafana-rc
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+  template:
+    metadata:
+      labels: 
+        name: grafana
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: infracloud/grafana
+        imagePullPolicy: Always
+        name: grafana

--- a/kubernetes-templates/Prometheus/1/grafana-srv.yml
+++ b/kubernetes-templates/Prometheus/1/grafana-srv.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+  namespace: "default"
+spec:
+  type: NodePort
+  ports:
+  - name: "grafana"
+    port: 3000
+    protocol: TCP
+  selector:
+    name: grafana

--- a/kubernetes-templates/Prometheus/1/influxdb-rc.yml
+++ b/kubernetes-templates/Prometheus/1/influxdb-rc.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+  name: influxdb-rc
+  namespace: default
+spec:
+  replicas: 1
+  
+  template:
+    metadata:
+      labels: 
+        name: influxdb
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: tutum/influxdb:0.13
+        imagePullPolicy: Always
+        name: influxdb
+        env:
+          - name: PRE_CREATE_DB
+            value: grafana;prometheus;rancher
+          - name: GRAPHITE_DB
+            value: rancher
+          - name: GRAPHITE_BINDING
+            value: :2003

--- a/kubernetes-templates/Prometheus/1/influxdb-srv.yml
+++ b/kubernetes-templates/Prometheus/1/influxdb-srv.yml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: influxdb
+  namespace: "default"
+spec:
+  type: NodePort
+  ports:
+  - port: 8083
+    protocol: TCP
+    name: idb-1
+  - port: 8086
+    protocol: TCP
+    name: idb-2
+  - port: 8090
+    protocol: TCP
+    name: idb-3
+  - port: 2003
+    protocol: TCP
+    name: idb-4
+  selector:
+    name: influxdb

--- a/kubernetes-templates/Prometheus/1/node-exporter-rc.yml
+++ b/kubernetes-templates/Prometheus/1/node-exporter-rc.yml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+  name: node-exporter-rc
+  namespace: default
+spec:
+  replicas: 1
+  
+  template:
+    metadata:
+      labels: 
+        name: node-exporter
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: prom/node-exporter:latest
+        imagePullPolicy: Always
+        name: node-exporter
+
+

--- a/kubernetes-templates/Prometheus/1/node-exporter-srv.yml
+++ b/kubernetes-templates/Prometheus/1/node-exporter-srv.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: node-exporter
+  namespace: "default"
+spec:
+
+  ports:
+  - name: "node-exporter"
+    port: 9100
+    protocol: TCP
+  selector:
+    name: node-exporter

--- a/kubernetes-templates/Prometheus/1/prometheus-rancher-exporter-rc.yml
+++ b/kubernetes-templates/Prometheus/1/prometheus-rancher-exporter-rc.yml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: prometheus-rancher-exporter-rc
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+  template:
+    metadata:
+      labels: 
+        name: prometheus-rancher-exporter
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: infinityworks/prometheus-rancher-exporter:v0.22.52
+        imagePullPolicy: Always
+        name: prometheus-rancher-exporter
+        ports:
+        - containerPort: 9010
+        env:
+        - name: CATTLE_ACCESS_KEY
+          value: "${cattle_access_key}"
+        - name: CATTLE_SECRET_KEY
+          value: "${cattle_secret_key}"
+        - name: CATTLE_URL
+          value: "${cattle_url}"

--- a/kubernetes-templates/Prometheus/1/prometheus-rancher-exporter-srv.yml
+++ b/kubernetes-templates/Prometheus/1/prometheus-rancher-exporter-srv.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prom-rancher-exporter
+  namespace: "default"
+spec:
+
+  ports:
+  - name: prometheus-rancher-exporter
+    port: 9010
+    protocol: TCP
+  selector:
+    name: prometheus-rancher-exporter

--- a/kubernetes-templates/Prometheus/1/prometheus-rc.yml
+++ b/kubernetes-templates/Prometheus/1/prometheus-rc.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: prometheus-rc
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+  template:
+    metadata:
+      labels: 
+        name: prometheus
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: infracloud/prometheus
+        command: 
+          - /bin/prometheus
+          - -alertmanager.url=http://alertmanager:9093 
+          - -config.file=/etc/prometheus/prometheus.yml 
+          - -storage.local.path=/prometheus -web.console.libraries=/etc/prometheus/console_libraries 
+          - -web.console.templates=/etc/prometheus/consoles
+        imagePullPolicy: Always
+        name: prometheus
+        ports:
+        - containerPort: 9090

--- a/kubernetes-templates/Prometheus/1/prometheus-srv.yml
+++ b/kubernetes-templates/Prometheus/1/prometheus-srv.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus
+  namespace: "default"
+spec:
+  type: NodePort
+  ports:
+  - name: "prometheus"
+    port: 9090
+    protocol: TCP
+   
+  selector:
+    name: prometheus

--- a/kubernetes-templates/Prometheus/1/ranch-eye-rc.yml
+++ b/kubernetes-templates/Prometheus/1/ranch-eye-rc.yml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    io.rancher.scheduler.global: "true"
+    io.rancher.container.dns: "true"
+  name: ranch-eye-rc
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+  template:
+    metadata:
+      labels: 
+        name: ranch-eye
+    spec:
+      restartPolicy: Always
+      containers:
+      - image: infracloud/ranch-eye
+        imagePullPolicy: Always
+        name: ranch-eye
+        env:
+        - name: CADVISOR_HOST_IP
+          value: "${host_ip}"
+
+

--- a/kubernetes-templates/Prometheus/1/ranch-eye-srv.yml
+++ b/kubernetes-templates/Prometheus/1/ranch-eye-srv.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ranch-eye
+  labels:
+    io.rancher.scheduler.global: "true"
+    io.rancher.container.dns: "true"
+spec:
+  ports:
+  - port: 9104
+    protocol: TCP
+    targetPort: 9104
+  selector:
+    name: ranch-eye

--- a/kubernetes-templates/Prometheus/1/rancher-compose.yml
+++ b/kubernetes-templates/Prometheus/1/rancher-compose.yml
@@ -1,0 +1,77 @@
+.catalog:
+  name: "Prometheus"
+  version: "2.1.0"
+  description: "Prometheus Monitoring Solution"
+  uuid: prometheus-2
+  minimum_rancher_version: v1.1.99
+  questions:
+    - variable: "cattle_url"
+      label: "Rancher Server URL"
+      required: true
+      default: "http://127.0.0.1:8080"
+      type: "string"
+    - variable: "cattle_access_key"
+      label: "Rancher Environement Access Key"
+      required: true
+      default: "349CE0C4418D09F1D4AC"
+      type: "string"
+    - variable: "cattle_secret_key"
+      label: "Rancher Environement Secret Key"
+      required: true
+      default: "HdhPUKDhUCzGVyrFHW1UJ1thc5LFtfkYVH4Ge8QL"
+      type: "string"
+    - variable: "host_ip"
+      label: "Host IP for Rancher Agent"
+      required: true
+      default: "127.0.0.1"
+      type: "string"
+
+ranch-eye:
+  upgrade_strategy:
+    start_first: true
+
+node-exporter:
+  upgrade_strategy:
+    start_first: true
+
+prometheus:
+  scale: 1
+  health_check:
+    port: 9090
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+influxdb:
+  scale: 1
+  health_check:
+    port: 8086
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+grafana:
+  scale: 1
+  health_check:
+    port: 3000
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000
+
+prometheus-rancher-exporter:
+  scale: 1
+  upgrade_strategy:
+    start_first: true
+  health_check:
+    port: 9173
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: ''
+    healthy_threshold: 2
+    response_timeout: 5000

--- a/kubernetes-templates/Prometheus/config.yml
+++ b/kubernetes-templates/Prometheus/config.yml
@@ -1,4 +1,4 @@
 name: "Prometheus"
 description: "Prometheus and friends, auto-discovering monitoring solution for Rancher deployments"
-version: "1.1.0"
+version: "2.1.0"
 category: "Monitoring"


### PR DESCRIPTION
Upgrade prometheus-rancher-exporter-rc to fix startup error in Rancher 1.3.4+.
influxdb image is also upgraded to 0.13.

This PR fixes the prometheus-rancher-exporter-rc pod startup error described in this ticket:
https://github.com/infinityworksltd/prometheus-rancher-exporter/issues/9
by upgrading the prometheus-rancher-exporter-rc RC image to the currently latest v0.22.52.

The dependency versions roughly correspond to the ones in the Prometheus template of the latest version [here](https://github.com/rancher/community-catalog/tree/master/templates/Prometheus/4)
The differences are:
* prometheus-rancher-exporter-rc version v0.22.52 (vs v0.22.40 in the template)
* influxdb version 0.13 (vs 0.10 in the template)

Other template components that didn't list image version explicitly in the `kubernetes-templates` remain unchanged.
