### PR TITLE
Update GoCD template

### DIFF
--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if (strings.Contains .Values.VOLUME_DRIVER_SERVER "/")}}
+    {{- if (hasPrefix .Values.VOLUME_DRIVER_SERVER "/")}}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -36,7 +36,7 @@ services:
       - GOCD_PLUGIN_google-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/google-oauth-login-2.3.jar
       - GOCD_PLUGIN_github-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/github-oauth-login-2.3.jar
       {{- end}}
-    {{- if and (ne .Values.DEPLOY_LB "true") (ne .Values.PUBLISH_PORT "false")}}
+    {{- if and (ne .Values.DEPLOY_LB "true") (.Values.PUBLISH_PORT)}}
     ports:
       - ${PUBLISH_PORT}:8153
     {{- end}}
@@ -46,7 +46,7 @@ services:
     {{- if eq .Values.DEPLOY_LB "true"}}
   lb:
     image: rancher/lb-service-haproxy:v0.6.2
-      {{- if (ne .Values.PUBLISH_PORT "false")}}
+      {{- if (.Values.PUBLISH_PORT)}}
     ports:
       - ${PUBLISH_PORT}:8153/tcp
       {{- else}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,8 +5,8 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if call strings.HasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
-      - /data/gocd-test:/data
+    {{- if eq (printf "%.1s" .Values.VOLUME_DRIVER_SERVER) "/" }}
+      - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data
     {{- end}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if hasPrefix string(.Values.VOLUME_DRIVER_SERVER) "/" }}
+    {{- if hasPrefix (string .Values.VOLUME_DRIVER_SERVER) "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if (contains .Values.VOLUME_DRIVER_SERVER "/")}}
+    {{- if (strings.Contains .Values.VOLUME_DRIVER_SERVER "/")}}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -36,7 +36,7 @@ services:
       - GOCD_PLUGIN_google-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/google-oauth-login-2.3.jar
       - GOCD_PLUGIN_github-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/github-oauth-login-2.3.jar
       {{- end}}
-    {{- if (ne .Values.DEPLOY_LB "true") and .Values.PUBLISH_PORT and (ne .Values.PUBLISH_PORT "")}}
+    {{- if (ne .Values.DEPLOY_LB "true") and (ne .Values.PUBLISH_PORT "false")}}
     ports:
       - ${PUBLISH_PORT}:8153
     {{- end}}
@@ -46,7 +46,7 @@ services:
     {{- if eq .Values.DEPLOY_LB "true"}}
   lb:
     image: rancher/lb-service-haproxy:v0.6.2
-      {{- if .Values.PUBLISH_PORT and (ne .Values.PUBLISH_PORT "")}}
+      {{- if (ne .Values.PUBLISH_PORT "false")}}
     ports:
       - ${PUBLISH_PORT}:8153/tcp
       {{- else}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -36,7 +36,7 @@ services:
       - GOCD_PLUGIN_google-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/google-oauth-login-2.3.jar
       - GOCD_PLUGIN_github-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/github-oauth-login-2.3.jar
       {{- end}}
-    {{- if (ne .Values.DEPLOY_LB "true") and (ne .Values.PUBLISH_PORT "false")}}
+    {{- if and (ne .Values.DEPLOY_LB "true") (ne .Values.PUBLISH_PORT "false")}}
     ports:
       - ${PUBLISH_PORT}:8153
     {{- end}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
+    {{- if call hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if (hasPrefix .Values.VOLUME_DRIVER_SERVER "/")}}
+    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -36,7 +36,7 @@ services:
       - GOCD_PLUGIN_google-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/google-oauth-login-2.3.jar
       - GOCD_PLUGIN_github-auth=https://github.com/gocd-contrib/gocd-oauth-login/releases/download/v2.3/github-oauth-login-2.3.jar
       {{- end}}
-    {{- if (ne .Values.DEPLOY_LB "true") and .Values.PUBLISH_PORT}}
+    {{- if (ne .Values.DEPLOY_LB "true") and .Values.PUBLISH_PORT and (ne .Values.PUBLISH_PORT "")}}
     ports:
       - ${PUBLISH_PORT}:8153
     {{- end}}
@@ -46,7 +46,7 @@ services:
     {{- if eq .Values.DEPLOY_LB "true"}}
   lb:
     image: rancher/lb-service-haproxy:v0.6.2
-      {{- if .Values.PUBLISH_PORT}}
+      {{- if .Values.PUBLISH_PORT and (ne .Values.PUBLISH_PORT "")}}
     ports:
       - ${PUBLISH_PORT}:8153/tcp
       {{- else}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if call hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
+    {{- if call strings.HasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
       - /data/gocd-test:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if eq (substr .Values.VOLUME_DRIVER_SERVER 0 1) "/" }}
+    {{- if hasPrefix string(.Values.VOLUME_DRIVER_SERVER) "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data
@@ -114,12 +114,12 @@ volumes:
   gocd-scheduler-setting:
     driver: local
     per_container: true
-  {{- if ne (substr .Values.VOLUME_DRIVER_AGENT 0 1) "/"}}
+  {{- if not (contains .Values.VOLUME_DRIVER_AGENT "/")}}
   gocd-agent-data:
     driver: ${VOLUME_DRIVER_AGENT}
     per_container: true
   {{- end}}
-  {{- if ne (substr .Values.VOLUME_DRIVER_SERVER 0 1) "/"}}
+  {{- if not (contains .Values.VOLUME_DRIVER_SERVER "/")}}
   gocd-server-data:
     driver: ${VOLUME_DRIVER_SERVER}
   {{- end}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -6,7 +6,7 @@ services:
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
     {{- if call hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
-      - ${VOLUME_DRIVER_SERVER}:/data
+      - /data/gocd-test:/data
     {{- else}}
       - gocd-server-data:/data
     {{- end}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "\/" }}
+    {{- if eq (substr .Values.VOLUME_DRIVER_SERVER 0 1) "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data
@@ -114,12 +114,12 @@ volumes:
   gocd-scheduler-setting:
     driver: local
     per_container: true
-  {{- if not (contains .Values.VOLUME_DRIVER_AGENT "/")}}
+  {{- if ne (substr .Values.VOLUME_DRIVER_AGENT 0 1) "/"}}
   gocd-agent-data:
     driver: ${VOLUME_DRIVER_AGENT}
     per_container: true
   {{- end}}
-  {{- if not (contains .Values.VOLUME_DRIVER_SERVER "/")}}
+  {{- if ne (substr .Values.VOLUME_DRIVER_SERVER 0 1) "/"}}
   gocd-server-data:
     driver: ${VOLUME_DRIVER_SERVER}
   {{- end}}

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if hasPrefix (string .Values.VOLUME_DRIVER_SERVER) "/" }}
+    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -5,7 +5,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-server:17.3.0-1
     volumes:
-    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "/" }}
+    {{- if hasPrefix .Values.VOLUME_DRIVER_SERVER "\/" }}
       - ${VOLUME_DRIVER_SERVER}:/data
     {{- else}}
       - gocd-server-data:/data

--- a/templates/gocd/0/docker-compose.yml.tpl
+++ b/templates/gocd/0/docker-compose.yml.tpl
@@ -65,7 +65,7 @@ services:
     tty: true
     image: webcenter/alpine-gocd-agent:17.3.0-1
     volumes:
-    {{- if (contains .Values.VOLUME_DRIVER_AGENT "/")}}
+    {{- if eq (printf "%.1s" .Values.VOLUME_DRIVER_AGENT) "/"}}
       - ${VOLUME_DRIVER_AGENT}:/data
     {{- else}}
       - gocd-agent-data:/data
@@ -102,7 +102,7 @@ services:
       io.rancher.container.hostname_override: container_name
     image: index.docker.io/docker:1.13-dind
     volumes:
-    {{- if (contains .Values.VOLUME_DRIVER_AGENT "/")}}
+    {{- if eq (printf "%.1s" .Values.VOLUME_DRIVER_AGENT) "/"}}
       - ${VOLUME_DRIVER_AGENT}:/data
     {{- else}}
       - gocd-agent-data:/data
@@ -114,12 +114,12 @@ volumes:
   gocd-scheduler-setting:
     driver: local
     per_container: true
-  {{- if not (contains .Values.VOLUME_DRIVER_AGENT "/")}}
+  {{- if ne (printf "%.1s" .Values.VOLUME_DRIVER_AGENT) "/"}}
   gocd-agent-data:
     driver: ${VOLUME_DRIVER_AGENT}
     per_container: true
   {{- end}}
-  {{- if not (contains .Values.VOLUME_DRIVER_SERVER "/")}}
+  {{- if ne (printf "%.1s" .Values.VOLUME_DRIVER_SERVER) "/"}}
   gocd-server-data:
     driver: ${VOLUME_DRIVER_SERVER}
   {{- end}}

--- a/templates/gocd/0/rancher-compose.yml
+++ b/templates/gocd/0/rancher-compose.yml
@@ -93,7 +93,7 @@ catalog:
         - "true"
         - "false"
     - variable: "PUBLISH_PORT"
-      description: "Set port if you want publish external port for GoCD server or Loadbalancer. Else set 'false'"
+      description: "Set port if you want publish external port for GoCD server or Loadbalancer"
       label: "Publish port"
       required: false
       type: "string"

--- a/templates/gocd/0/rancher-compose.yml
+++ b/templates/gocd/0/rancher-compose.yml
@@ -93,7 +93,7 @@ catalog:
         - "true"
         - "false"
     - variable: "PUBLISH_PORT"
-      description: "Set port if you want publish external port for GoCD server or Loadbalancer"
+      description: "Set port if you want publish external port for GoCD server or Loadbalancer. Else set 'false'"
       label: "Publish port"
       required: false
       type: "string"


### PR DESCRIPTION
Hi,

I found a bug and fix it when instanciate GoCD Template with path to to store persistance data (replace local by /mnt/gocd-server for exemple).
The `hasPrefix` function seems not working on templating. I replace it by ` if eq (printf "%.1s" .Values.VOLUME_DRIVER_SERVER) "/"` and all work as expected.