### PR TITLE
Upgraded DigitalOcean DNS to v0.6.4

### DIFF
--- a/infra-templates/digitalocean-dns/2/README.md
+++ b/infra-templates/digitalocean-dns/2/README.md
@@ -1,0 +1,53 @@
+## DigitalOcean DNS
+
+Rancher External DNS service powered by DigitalOcean
+
+#### Changelog
+
+##### v0.6.4
+
+* Adds support for overriding name template for specific services by setting io.rancher.service.external_dns_name_template label to it in docker-compose.yml
+
+#### Usage
+
+##### DigitalOcean DNS record TTL
+The DigitalOcean API currently does not support per-record TTL setting. You should configure the global TTL setting for the domain manually and set it to a low value (e.g. 60).
+
+##### Limitation when running the service on multiple Rancher servers
+
+When running multiple instances of the External DNS service configured to use the same domain name, then only one of them can run in the "Default" environment of a Rancher server instance.
+
+##### Supported host labels
+
+`io.rancher.host.external_dns_ip`     
+Override the IP address used in DNS records for containers running on the host. Defaults to the IP address the host is registered with in Rancher.
+      
+`io.rancher.host.external_dns`    
+Accepts 'true' (default) or 'false'    
+When this is set to 'false' no DNS records will ever be created for containers running on this host.
+
+##### Supported service labels
+
+`io.rancher.service.external_dns`     
+Accepts 'always', 'never' or 'auto' (default)  
+- `always`: Always create DNS records for this service
+- `never`: Never create DNS records for this service
+- `auto`: Create DNS records for this service if it exposes ports on the host
+
+`io.rancher.service.external_dns_name_template`
+Custom DNS name template that overrides global custom DNS name template (see below) of default DNS name template for a specific service
+     
+##### Custom DNS name template
+
+By default DNS entries are named `<service>.<stack>.<environment>.<domain>`.    
+You can specify a custom name template used to construct the subdomain part (left of the domain/zone name) of the DNS records. The following placeholders are supported:
+
+* `%{{service_name}}`
+* `%{{stack_name}}`
+* `%{{environment_name}}`
+
+**Example:**
+
+`%{{stack_name}}-%{{service_name}}.statictext`
+
+Make sure to only use characters in static text and separators that your provider allows in DNS names.

--- a/infra-templates/digitalocean-dns/2/docker-compose.yml
+++ b/infra-templates/digitalocean-dns/2/docker-compose.yml
@@ -1,0 +1,13 @@
+digitalocean:
+  image: rancher/external-dns:v0.6.4
+  command: -provider=digitalocean
+  expose:
+   - 1000
+  environment:
+    DO_PAT: ${DO_PAT}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    NAME_TEMPLATE: ${NAME_TEMPLATE}
+    TTL: 300
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/infra-templates/digitalocean-dns/2/rancher-compose.yml
+++ b/infra-templates/digitalocean-dns/2/rancher-compose.yml
@@ -1,0 +1,34 @@
+.catalog:
+  name: "DigitalOcean DNS"
+  version: "v0.6.4"
+  description: "Rancher External DNS service powered by DigitalOcean"
+  minimum_rancher_version: v1.5.0
+  questions:
+    - variable: "DO_PAT"
+      label: "DigitalOcean Personal Access Token"
+      description: "Enter your personal access token"
+      type: "string"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Domain Name"
+      description: "The domain name managed by DigitalOcean."
+      type: "string"
+      required: true
+    - variable: "NAME_TEMPLATE"
+      label: "DNS Name Template"
+      description: |
+        Name template used to construct the subdomain part (left of the domain) of the DNS record names.
+        Supported placeholders: %{{service_name}}, %{{stack_name}}, %{{environment_name}}.
+        By default DNS entries will be named '<service>.<stack>.<environment>.<domain>'.
+      type: "string"
+      default: "%{{service_name}}.%{{stack_name}}.%{{environment_name}}"
+      required: false
+
+digitalocean:
+  health_check:
+    port: 1000
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/infra-templates/digitalocean-dns/config.yml
+++ b/infra-templates/digitalocean-dns/config.yml
@@ -1,7 +1,7 @@
 name: DigitalOcean DNS
 description: |
   Rancher External DNS service powered by DigitalOcean
-version: v0.6.3
+version: v0.6.4
 category: External DNS
 labels:
   io.rancher.orchestration.supported: 'cattle,mesos,swarm,kubernetes'


### PR DESCRIPTION
Adds support for overriding name template for specific services by setting `io.rancher.service.external_dns_name_template` label to it in `docker-compose.yml`.

Implemented in https://github.com/rancher/external-dns/pull/74