### PR TITLE
Letsencrypt v0.5.0

### DIFF
--- a/templates/letsencrypt/4/README.md
+++ b/templates/letsencrypt/4/README.md
@@ -1,0 +1,86 @@
+# Let's Encrypt Certificate Manager
+
+### About
+The Let's Encrypt Certificate Manager obtains a free (SAN) SSL Certificate from the [Let's Encrypt CA](https://letsencrypt.org/) and adds it to Rancher's certificate store. Once the certificate is created it is scheduled for automatic renewal 20-days before expiration. Rancher load balancer services are automatically updated to use the renewed certificate.
+     
+### Usage
+ 1. Accept the terms of service.
+ 2. Select the API version to use. The Sandbox API should be used for testing purposes.
+ 3. Fill in your email address.
+ 4. Enter the name used for storing the certificate in Rancher and volumes. Any existing certificate by that name will be updated.
+ 5. Enter one or more domain names. The first domain will be used as the Common Name property of the certificate.
+ 6. Fill in the required credentials for the chosen provider. Note provider specific usage notes below.
+
+If you want the certificate to be automatically renewed, leave the service running. Otherwise you may remove the service once the certificate has appeared in Rancher's certificate store.
+
+### Using persistent storage volume
+
+If you specify an existing volume storage driver (e.g. rancher-nfs) then the account data, certificate and private key will be stored in a stack scoped volume named `lets-encrypt`, allowing you to access them from other services in the same stack. See the [Storage Service documentation](https://docs.rancher.com/rancher/v1.3/en/rancher-services/storage-service/).
+
+#### Example
+
+When mounting the `lets-encrypt` storage volume to `/etc/letsencrypt` in another container, then production certificates and keys are located at:
+ 
+- `/etc/letsencrypt/production/certs/<certificate name>/fullchain.pem`
+- `/etc/letsencrypt/production/certs/<certificate name>/privkey.pem`
+
+where `<certificate name>` is the name of the certificate sanitized to consist of only the following characters: `[a-zA-Z0-9-_.]`.
+    
+### Provider specific usage
+
+#### AWS Route 53
+
+The following IAM policy describes the minimum permissions required when using AWS Route 53 for domain authorization.    
+Replace `<HOSTED_ZONE_ID>` with the ID of the hosted zone that encloses the domain(s) for which you are going to obtain certificates. You may use a wildcard (*) in place of the ID to make this policy work with all of the hosted zones associated with an AWS account.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:GetChange",
+                "route53:ListHostedZonesByName"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<HOSTED_ZONE_ID>"
+            ]
+        }
+    ]
+}
+```
+
+#### OVH
+
+First create your credentials on https://eu.api.ovh.com/createToken/ by filling out the form like this:
+
+- `Account ID`: Your OVH account ID
+- `Password`: Your password
+- `Script name`: letsencrypt
+- `Script description`: Letsencrypt for Rancher
+- `Validity`: Unlimited
+- `Rights`:
+  - GET /domain/zone/*
+  - POST /domain/zone/*
+  - DELETE /domain/zone/*
+
+Then deploy this service using the generated key, application secret and consumer key.
+
+#### HTTP
+
+If you prefer not to use a DNS-based challenge or your provider is not supported, you can use the HTTP challenge.
+Simply choose `HTTP` from the list of providers.
+Then make sure that HTTP requests to `domain.com/.well-known/acme-challenge` are forwarded to the `rancher-letsencrypt` service, e.g. by configuring a Rancher load balancer accordingly.
+
+### Suggestions & bug reports
+Please submit suggestions or any issues you find to the [rancher-letsencrypt](https://github.com/janeczku/rancher-letsencrypt) GitHub repo.

--- a/templates/letsencrypt/4/README.md
+++ b/templates/letsencrypt/4/README.md
@@ -2,6 +2,15 @@
 
 ### About
 The Let's Encrypt Certificate Manager obtains a free (SAN) SSL Certificate from the [Let's Encrypt CA](https://letsencrypt.org/) and adds it to Rancher's certificate store. Once the certificate is created it is scheduled for automatic renewal 20-days before expiration. Rancher load balancer services are automatically updated to use the renewed certificate.
+
+### Changelog v0.5.0
+
+- Added support for Aurora DNS, Azure DNS and NS1
+- Added support for stopping container after creating/renewing certificate
+- Added configuration option to specify DNS resolvers to use (fixes an issue with private zones on AWS)
+- Added configuration option to specify renewal grace period
+- Added support for Rancher servers using self-signed certs
+- Logs now contain ACME library messages
      
 ### Usage
  1. Accept the terms of service.
@@ -13,13 +22,17 @@ The Let's Encrypt Certificate Manager obtains a free (SAN) SSL Certificate from 
 
 If you want the certificate to be automatically renewed, leave the service running. Otherwise you may remove the service once the certificate has appeared in Rancher's certificate store.
 
-### Using persistent storage volume
+### Store data in a persistent volume
 
-If you specify an existing volume storage driver (e.g. rancher-nfs) then the account data, certificate and private key will be stored in a stack scoped volume named `lets-encrypt`, allowing you to access them from other services in the same stack. See the [Storage Service documentation](https://docs.rancher.com/rancher/v1.3/en/rancher-services/storage-service/).
+If you specify a name under "Volume Name" then account data, certificate and private key are stored in a (host scoped) Docker volume with the specified name.
+To store the data in a stack scoped volume that can be shared with services running on other hosts, you should provide the name of an already active persistent storage service under "Persistent Storage Driver". See the [Storage Service documentation](https://docs.rancher.com/rancher/v1.3/en/rancher-services/storage-service/).
 
 #### Example
 
-When mounting the `lets-encrypt` storage volume to `/etc/letsencrypt` in another container, then production certificates and keys are located at:
+1. Configure the service with a volume named "letsencrypt".
+2. Mount the volume to `/etc/letsencrypt` in another service.
+
+This service can then access the certificate and key in the following locations:
  
 - `/etc/letsencrypt/production/certs/<certificate name>/fullchain.pem`
 - `/etc/letsencrypt/production/certs/<certificate name>/privkey.pem`
@@ -29,6 +42,8 @@ where `<certificate name>` is the name of the certificate sanitized to consist o
 ### Provider specific usage
 
 #### AWS Route 53
+
+Note: If you have both a private and public zone for the domain, make sure you configure the service to use public DNS resolvers (the default ones are fine).
 
 The following IAM policy describes the minimum permissions required when using AWS Route 53 for domain authorization.    
 Replace `<HOSTED_ZONE_ID>` with the ID of the hosted zone that encloses the domain(s) for which you are going to obtain certificates. You may use a wildcard (*) in place of the ID to make this policy work with all of the hosted zones associated with an AWS account.
@@ -80,7 +95,7 @@ Then deploy this service using the generated key, application secret and consume
 
 If you prefer not to use a DNS-based challenge or your provider is not supported, you can use the HTTP challenge.
 Simply choose `HTTP` from the list of providers.
-Then make sure that HTTP requests to `domain.com/.well-known/acme-challenge` are forwarded to the `rancher-letsencrypt` service, e.g. by configuring a Rancher load balancer accordingly.
+Then make sure that HTTP requests to `domain.com/.well-known/acme-challenge` are forwarded to port 80 of the `rancher-letsencrypt` service, e.g. by configuring a Rancher load balancer accordingly. Make sure the reverse proxy passes the original `host` header to the backend.
 
 ### Suggestions & bug reports
 Please submit suggestions or any issues you find to the [rancher-letsencrypt](https://github.com/janeczku/rancher-letsencrypt) GitHub repo.

--- a/templates/letsencrypt/4/docker-compose.yml
+++ b/templates/letsencrypt/4/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '2'
+services:
+  letsencrypt:
+    image: janeczku/rancher-letsencrypt:v0.4.0
+    environment:
+      EULA: ${EULA}
+      API_VERSION: ${API_VERSION}
+      CERT_NAME: ${CERT_NAME}
+      EMAIL: ${EMAIL}
+      DOMAINS: ${DOMAINS}
+      PUBLIC_KEY_TYPE: ${PUBLIC_KEY_TYPE}
+      RENEWAL_TIME: ${RENEWAL_TIME}
+      PROVIDER: ${PROVIDER}
+      CLOUDFLARE_EMAIL: ${CLOUDFLARE_EMAIL}
+      CLOUDFLARE_KEY: ${CLOUDFLARE_KEY}
+      DO_ACCESS_TOKEN: ${DO_ACCESS_TOKEN}
+      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
+      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
+      DNSIMPLE_EMAIL: ${DNSIMPLE_EMAIL}
+      DNSIMPLE_KEY: ${DNSIMPLE_KEY}
+      DYN_CUSTOMER_NAME: ${DYN_CUSTOMER_NAME}
+      DYN_USER_NAME: ${DYN_USER_NAME}
+      DYN_PASSWORD: ${DYN_PASSWORD}
+      VULTR_API_KEY: ${VULTR_API_KEY}
+      OVH_APPLICATION_KEY: ${OVH_APPLICATION_KEY}
+      OVH_APPLICATION_SECRET: ${OVH_APPLICATION_SECRET}
+      OVH_CONSUMER_KEY: ${OVH_CONSUMER_KEY}
+      GANDI_API_KEY: ${GANDI_API_KEY}
+    volumes:
+      - lets-encrypt:/etc/letsencrypt
+    labels:
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.agent.role: 'environment'
+volumes:
+  lets-encrypt:
+    driver: ${STORAGE_DRIVER}

--- a/templates/letsencrypt/4/docker-compose.yml
+++ b/templates/letsencrypt/4/docker-compose.yml
@@ -1,36 +1,62 @@
 version: '2'
 services:
   letsencrypt:
-    image: janeczku/rancher-letsencrypt:v0.4.0
+    image: janeczku/rancher-letsencrypt:v0.5.0
     environment:
-      EULA: ${EULA}
-      API_VERSION: ${API_VERSION}
-      CERT_NAME: ${CERT_NAME}
-      EMAIL: ${EMAIL}
-      DOMAINS: ${DOMAINS}
-      PUBLIC_KEY_TYPE: ${PUBLIC_KEY_TYPE}
-      RENEWAL_TIME: ${RENEWAL_TIME}
-      PROVIDER: ${PROVIDER}
-      CLOUDFLARE_EMAIL: ${CLOUDFLARE_EMAIL}
-      CLOUDFLARE_KEY: ${CLOUDFLARE_KEY}
-      DO_ACCESS_TOKEN: ${DO_ACCESS_TOKEN}
-      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
-      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      DNSIMPLE_EMAIL: ${DNSIMPLE_EMAIL}
-      DNSIMPLE_KEY: ${DNSIMPLE_KEY}
-      DYN_CUSTOMER_NAME: ${DYN_CUSTOMER_NAME}
-      DYN_USER_NAME: ${DYN_USER_NAME}
-      DYN_PASSWORD: ${DYN_PASSWORD}
-      VULTR_API_KEY: ${VULTR_API_KEY}
-      OVH_APPLICATION_KEY: ${OVH_APPLICATION_KEY}
-      OVH_APPLICATION_SECRET: ${OVH_APPLICATION_SECRET}
-      OVH_CONSUMER_KEY: ${OVH_CONSUMER_KEY}
-      GANDI_API_KEY: ${GANDI_API_KEY}
+      EULA: "${EULA}"
+      API_VERSION: "${API_VERSION}"
+      CERT_NAME: "${CERT_NAME}"
+      EMAIL: "${EMAIL}"
+      DOMAINS: "${DOMAINS}"
+      PUBLIC_KEY_TYPE: "${PUBLIC_KEY_TYPE}"
+      RENEWAL_TIME: "${RENEWAL_TIME}"
+      PROVIDER: "${PROVIDER}"
+      DNS_RESOLVERS: "${DNS_RESOLVERS}"
+      RENEWAL_PERIOD_DAYS: "${RENEWAL_PERIOD_DAYS}"
+      RUN_ONCE: "${RUN_ONCE}"
+      CLOUDFLARE_EMAIL: "${CLOUDFLARE_EMAIL}"
+      CLOUDFLARE_KEY: "${CLOUDFLARE_KEY}"
+      DO_ACCESS_TOKEN: "${DO_ACCESS_TOKEN}"
+      AWS_ACCESS_KEY: "${AWS_ACCESS_KEY}"
+      AWS_SECRET_KEY: "${AWS_SECRET_KEY}"
+      DNSIMPLE_EMAIL: "${DNSIMPLE_EMAIL}"
+      DNSIMPLE_KEY: "${DNSIMPLE_KEY}"
+      DYN_CUSTOMER_NAME: "${DYN_CUSTOMER_NAME}"
+      DYN_USER_NAME: "${DYN_USER_NAME}"
+      DYN_PASSWORD: "${DYN_PASSWORD}"
+      VULTR_API_KEY: "${VULTR_API_KEY}"
+      OVH_APPLICATION_KEY: "${OVH_APPLICATION_KEY}"
+      OVH_APPLICATION_SECRET: "${OVH_APPLICATION_SECRET}"
+      OVH_CONSUMER_KEY: "${OVH_CONSUMER_KEY}"
+      GANDI_API_KEY: "${GANDI_API_KEY}"
+      AZURE_CLIENT_ID: "${AZURE_CLIENT_ID}"
+      AZURE_CLIENT_SECRET: "${AZURE_CLIENT_SECRET}"
+      AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+      AZURE_TENANT_ID: "${AZURE_TENANT_ID}"
+      AZURE_RESOURCE_GROUP: "${AZURE_RESOURCE_GROUP}"
+      AURORA_USER_ID: "${AURORA_USER_ID}"
+      AURORA_KEY: "${AURORA_KEY}"
+      AURORA_ENDPOINT: "${AURORA_ENDPOINT}"
+      NS1_API_KEY: "${NS1_API_KEY}"
     volumes:
-      - lets-encrypt:/etc/letsencrypt
+      - /var/lib/rancher:/var/lib/rancher
+      {{- if .Values.VOLUME_NAME}}
+      - {{.Values.VOLUME_NAME}}:/etc/letsencrypt
+      {{- end }}
     labels:
-      io.rancher.container.create_agent: 'true'
-      io.rancher.container.agent.role: 'environment'
+      io.rancher.container.create_agent: "true"
+      io.rancher.container.agent.role: "environment"
+      {{- if eq .Values.RUN_ONCE "true" }}
+      io.rancher.container.start_once: "true"
+      {{- end }}
+{{- if .Values.VOLUME_NAME}}
 volumes:
-  lets-encrypt:
-    driver: ${STORAGE_DRIVER}
+  {{.Values.VOLUME_NAME}}:
+    {{- if .Values.STORAGE_DRIVER}}
+    driver: {{.Values.STORAGE_DRIVER}}
+    {{- if .Values.STORAGE_DRIVER_OPT}}
+    driver_opts:
+      {{.Values.STORAGE_DRIVER_OPT}}
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/templates/letsencrypt/4/rancher-compose.yml
+++ b/templates/letsencrypt/4/rancher-compose.yml
@@ -1,0 +1,163 @@
+.catalog:
+  name: Let's Encrypt
+  version: 0.4.0
+  description: Trusted SSL certificates at zero cost
+  minimum_rancher_version: v1.2.0-pre4-rc1
+  questions:
+    - variable: EULA
+      label: I Agree to the Let's Encrypt TOS
+      description: |
+        Read https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf
+      required: true
+      type: enum
+      options:
+        - "Yes"
+        - "No"
+    - variable: API_VERSION
+      label: Let's Encrypt API Version
+      description: |
+        Select the API version used for issuing the certificate.
+        Use `Sandbox` for testing only.
+      required: true
+      type: enum
+      default: Production
+      options:
+        - Production
+        - Sandbox
+    - variable: EMAIL
+      label: Your Email Address
+      description: |
+        Enter the email address to use for creating the Let's Encrypt account.
+      required: true
+      type: string
+    - variable: CERT_NAME
+      label: Certificate Name
+      description: |
+        Name for storing the certificate in the Rancher API and in volumes.
+        Any existing certificate by that name will be updated.
+      required: true
+      type: string
+    - variable: DOMAINS
+      label: Domain Names
+      description: |
+        Comma delimited list of the certificate domains starting with the Common Name.
+        E.g: `example.com, dev.example.com`.
+      required: true
+      type: string
+    - variable: PUBLIC_KEY_TYPE
+      label: Public Key Algorithm
+      description: |
+        Select one of the available key types.
+      required: true
+      type: enum
+      default: RSA-2048
+      options:
+        - RSA-2048
+        - RSA-4096
+        - RSA-8192
+        - ECDSA-256
+        - ECDSA-384
+    - variable: RENEWAL_TIME
+      label: Renewal Time of Day (00-23)
+      description: |
+        Set the time of day (UTC in hours) at which certificate renewals should be run.
+      default: 12
+      required: true
+      type: int
+    - variable: STORAGE_DRIVER
+      label: Volume Storage Driver (Optional)
+      description: |
+        If you enter the name of an existing storage driver (see `Infrastructure -> Storage`) then a stack scoped storage volume named `lets-encrypt`
+        will be created or used to store account data, certificates and private keys.
+      required: false
+      type: string
+    - variable: PROVIDER
+      label: Domain Validation Method
+      description: Select a DNS provider to use for domain validation. Use 'HTTP' if DNS for the domain is not hosted with any of the providers.
+      required: true
+      type: enum
+      options:
+        - CloudFlare
+        - DigitalOcean
+        - DNSimple
+        - Dyn
+        - Gandi
+        - HTTP
+        - Ovh
+        - Route53
+        - Vultr
+    - variable: AWS_ACCESS_KEY
+      label: AWS Route53 Access Key Id
+      description: Enter the Access Key Id for your AWS account.
+      type: string
+      required: false
+    - variable: AWS_SECRET_KEY
+      label: AWS Route53 Secret Access Key
+      description: Enter the Secret Access Key for your AWS account.
+      type: password
+      required: false
+    - variable: CLOUDFLARE_EMAIL
+      label: CloudFlare Email Address
+      description: Enter the email address associated with your CloudFlare account.
+      type: string
+      required: false
+    - variable: CLOUDFLARE_KEY
+      label: CloudFlare API Key
+      description: Enter the Global API Key for your CloudFlare account.
+      type: password
+      required: false
+    - variable: DO_ACCESS_TOKEN
+      label: DigitalOcean API Access Token
+      description: Enter the Personal Access Token for your DigitalOcean account.
+      type: password
+      required: false
+    - variable: DNSIMPLE_EMAIL
+      label: DNSimple Email Address
+      description: Enter the email address associated with your DNSimple account.
+      type: string
+      required: false
+    - variable: DNSIMPLE_KEY
+      label: DNSimple API Key
+      description: Enter your DNSimple API key.
+      type: password
+      required: false
+    - variable: DYN_CUSTOMER_NAME
+      label: Dyn Customer Name
+      description: Enter your Dyn customer name.
+      type: string
+      required: false
+    - variable: DYN_USER_NAME
+      label: Dyn User Name
+      description: Enter your Dyn user name.
+      type: string
+      required: false
+    - variable: DYN_PASSWORD
+      label: Dyn Password
+      description: Enter your Dyn password.
+      type: password
+      required: false
+    - variable: GANDI_API_KEY
+      label: Gandi API Key
+      description: Enter the API key for your Gandi account.
+      type: password
+      required: false
+    - variable: OVH_APPLICATION_KEY
+      label: OVH Application Key
+      description: Enter your OVH application key.
+      type: string
+      required: false
+    - variable: OVH_APPLICATION_SECRET
+      label: OVH Application Secret
+      description: Enter your OVH application secret.
+      type: password
+      required: false
+    - variable: OVH_CONSUMER_KEY
+      label: OVH Consumer Key
+      description: Enter your OVH consumer key.
+      type: password
+      required: false
+    - variable: VULTR_API_KEY
+      label: Vultr API Key
+      description: Enter the API key for your Vultr account.
+      type: password
+      required: false

--- a/templates/letsencrypt/4/rancher-compose.yml
+++ b/templates/letsencrypt/4/rancher-compose.yml
@@ -1,8 +1,8 @@
 .catalog:
   name: Let's Encrypt
-  version: 0.4.0
+  version: 0.5.0
   description: Trusted SSL certificates at zero cost
-  minimum_rancher_version: v1.2.0-pre4-rc1
+  minimum_rancher_version: v1.5.0
   questions:
     - variable: EULA
       label: I Agree to the Let's Encrypt TOS
@@ -16,8 +16,8 @@
     - variable: API_VERSION
       label: Let's Encrypt API Version
       description: |
-        Select the API version used for issuing the certificate.
-        Use `Sandbox` for testing only.
+        Select the Let's Encrypt API endpoint used for issuing the certificate.
+        Use `Sandbox` for testing your configuration.
       required: true
       type: enum
       default: Production
@@ -64,28 +64,79 @@
       default: 12
       required: true
       type: int
-    - variable: STORAGE_DRIVER
-      label: Volume Storage Driver (Optional)
+    - variable: RENEWAL_PERIOD_DAYS
+      label: Renewal Grace Period
       description: |
-        If you enter the name of an existing storage driver (see `Infrastructure -> Storage`) then a stack scoped storage volume named `lets-encrypt`
-        will be created or used to store account data, certificates and private keys.
+        Number of days before expiration the certificate should be renewed / become eligible for renewal.
+      default: 20
+      required: true
+      type: int
+    - variable: RUN_ONCE
+      label: Run Once
+      description: |
+        Stop the service after creating or renewing the certificate instead of continously running and managing renewal.
+      required: true
+      type: boolean
+      default: false
+    - variable: DNS_RESOLVERS
+      label: DNS Resolvers
+      description: |
+        Comma delimited list of DNS resolvers used to check propagation of ACME TXT record.
+        If empty the DNS resolvers configured in your hosts /etc/resolv.conf are used.
+      required: false
+      default: "8.8.8.8:53,8.8.4.4:53"
+      type: string
+    - variable: VOLUME_NAME
+      label: Volume Name (Optional)
+      description: |
+        To store the account data, certificates and private keys in a volume, enter the volume name that should be used.
+        By default this will be a (host scoped) named Docker volume. See "Persistent Storage Driver" for other options.
+      required: false
+      type: string
+    - variable: STORAGE_DRIVER
+      label: Persistent Storage Driver (Optional)
+      description: |
+        To use a stack scoped volume backed by a persistent storage service, enter the name
+        of an existing storage driver (see `Infrastructure -> Storage`). This also requires "Volume Name" to be set.
+      required: false
+      type: string
+    - variable: STORAGE_DRIVER_OPT
+      label: Storage Driver Option (Optional)
+      description: |
+        Specify a single "driver_opts" key/value pair in the format "optionName: optionValue".
+        E.g. for the `rancher-ebs` driver you should specify the required 'size' option like this: "size: 1".
       required: false
       type: string
     - variable: PROVIDER
-      label: Domain Validation Method
-      description: Select a DNS provider to use for domain validation. Use 'HTTP' if DNS for the domain is not hosted with any of the providers.
+      label: Domain Validation Provider
+      description: Select a DNS provider to use for domain validation. Use 'HTTP' if your domain is hosted elsewhere.
       required: true
       type: enum
       options:
+        - Aurora
+        - Azure
         - CloudFlare
         - DigitalOcean
         - DNSimple
         - Dyn
         - Gandi
-        - HTTP
+        - NS1
         - Ovh
         - Route53
         - Vultr
+        - HTTP
+    - variable: AURORA_USER_ID
+      label: Aurora User ID
+      type: string
+      required: false
+    - variable: AURORA_KEY
+      label: Aurora Key
+      type: string
+      required: false
+    - variable: AURORA_ENDPOINT
+      label: Aurora Endpoint URL (Optional)
+      type: string
+      required: false
     - variable: AWS_ACCESS_KEY
       label: AWS Route53 Access Key Id
       description: Enter the Access Key Id for your AWS account.
@@ -94,7 +145,27 @@
     - variable: AWS_SECRET_KEY
       label: AWS Route53 Secret Access Key
       description: Enter the Secret Access Key for your AWS account.
-      type: password
+      type: string
+      required: false
+    - variable: AZURE_CLIENT_ID
+      label: Azure Client ID
+      type: string
+      required: false
+    - variable: AZURE_CLIENT_SECRET
+      label: Azure Client Secret
+      type: string
+      required: false
+    - variable: AZURE_SUBSCRIPTION_ID
+      label: Azure Subscription ID
+      type: string
+      required: false
+    - variable: AZURE_TENANT_ID
+      label: Azure Tenant ID
+      type: string
+      required: false
+    - variable: AZURE_RESOURCE_GROUP
+      label: Azure Resource Group
+      type: string
       required: false
     - variable: CLOUDFLARE_EMAIL
       label: CloudFlare Email Address
@@ -104,12 +175,12 @@
     - variable: CLOUDFLARE_KEY
       label: CloudFlare API Key
       description: Enter the Global API Key for your CloudFlare account.
-      type: password
+      type: string
       required: false
     - variable: DO_ACCESS_TOKEN
       label: DigitalOcean API Access Token
       description: Enter the Personal Access Token for your DigitalOcean account.
-      type: password
+      type: string
       required: false
     - variable: DNSIMPLE_EMAIL
       label: DNSimple Email Address
@@ -119,7 +190,7 @@
     - variable: DNSIMPLE_KEY
       label: DNSimple API Key
       description: Enter your DNSimple API key.
-      type: password
+      type: string
       required: false
     - variable: DYN_CUSTOMER_NAME
       label: Dyn Customer Name
@@ -134,12 +205,16 @@
     - variable: DYN_PASSWORD
       label: Dyn Password
       description: Enter your Dyn password.
-      type: password
+      type: string
       required: false
     - variable: GANDI_API_KEY
       label: Gandi API Key
       description: Enter the API key for your Gandi account.
-      type: password
+      type: string
+      required: false
+    - variable: NS1_API_KEY
+      label: NS1 API Key
+      type: string
       required: false
     - variable: OVH_APPLICATION_KEY
       label: OVH Application Key
@@ -149,15 +224,15 @@
     - variable: OVH_APPLICATION_SECRET
       label: OVH Application Secret
       description: Enter your OVH application secret.
-      type: password
+      type: string
       required: false
     - variable: OVH_CONSUMER_KEY
       label: OVH Consumer Key
       description: Enter your OVH consumer key.
-      type: password
+      type: string
       required: false
     - variable: VULTR_API_KEY
       label: Vultr API Key
       description: Enter the API key for your Vultr account.
-      type: password
+      type: string
       required: false

--- a/templates/letsencrypt/config.yml
+++ b/templates/letsencrypt/config.yml
@@ -1,7 +1,7 @@
 name: Let's Encrypt
 description: |
   Trusted SSL certificates at zero cost
-version: 0.4.0
+version: 0.5.0
 category: Security
 maintainer: Jan Bruder <jan@rancher.com>
 license: The MIT License


### PR DESCRIPTION
### Changelog v0.5.0

- Added support for Aurora DNS, Azure DNS and NS1
- Added support for stopping container after creating/renewing certificate
- Added configuration option to specify DNS resolvers to use (fixes an issue with private zones on AWS)
- Added configuration option to specify renewal grace period
- Added support for Rancher servers using self-signed certs
- Logs now contain ACME library messages