### PR TITLE
Update Sematext catalog docker-compose.yml

### DIFF
--- a/templates/sematext/0/docker-compose.yml
+++ b/templates/sematext/0/docker-compose.yml
@@ -8,8 +8,8 @@ sematext-agent:
     - HTTP_PROXY=${http_proxy}
     - MATCH_BY_IMAGE=${match_by_image}
     - MATCH_BY_NAME=${match_by_name}
-    - SKIP_BY_IMAGE=${match_by_image}
-    - SKIP_BY_NAME=${match_by_name}
+    - SKIP_BY_IMAGE=${skip_by_image}
+    - SKIP_BY_NAME=${skip_by_name}
     - LOGAGENT_PATTERNS=${logagent_patterns}
     - KUBERNETES=${kubernetes}
   restart: always


### PR DESCRIPTION
The docker-compose.yml would not get the proper `skip_by_image` or `skip_by_name` if specified when deploying. The rancher template names were accidentally specified from the "match" fields.