### PR TITLE
Datadog template 11.0.5140

### DIFF
--- a/templates/datadog/6/README.md
+++ b/templates/datadog/6/README.md
@@ -1,0 +1,23 @@
+# Datadog agent
+
+This template deploys a [Datadog](https://www.datadoghq.com/) agent stack consisting of the official [docker-dd-agent](https://www.github.com/Datadog/docker-dd-agent) image and a configuration sidekick that provides closer integration with Rancher:
+
+* Hosts in Datadog are named correctly
+* Host labels can be exported as Datadog host tags
+* Service labels can be exported as Datadog metric tags
+
+## Service Discovery
+
+Please refer to the Datadog documentation [here](http://docs.datadoghq.com/guides/servicediscovery/) to learn how to provide configuration templates for Service Discovery in etcd or Consul.
+
+## Changelog
+
+**1.1.1-11.0.5140**
+
+* Datadog image updated to v5.1.40 which includes the following Rancher specific changes:
+    * Service Discovery: Add ability to get docker IP address from Rancher labels for Rancher
+    * Docker: Fix cgroup parsing on RancherOS
+* Switched to use the Alpine based agent image
+* Added template configuration of Proxy settings
+* Added template configuration to disable DogStatsD
+* Added template configuration to overwrite DD intake URL

--- a/templates/datadog/6/docker-compose.yml
+++ b/templates/datadog/6/docker-compose.yml
@@ -1,0 +1,47 @@
+datadog-init:
+  image: janeczku/datadog-rancher-init:v2.2.5
+  net: none
+  command: /bin/true
+  volumes:
+    - /opt/rancher
+  labels:
+    io.rancher.container.start_once: "true"
+    io.rancher.container.pull_image: always
+datadog-agent:
+  image: datadog/docker-dd-agent:11.0.5140
+  command: supervisord -n -c /etc/dd-agent/supervisor.conf
+  entrypoint: /opt/rancher/entrypoint-wrapper.py
+  restart: always
+  environment:
+    # Evaluated by datadog-agent image
+    API_KEY: ${api_key}
+    EC2_TAGS: ${dd_ec2_tags}
+    DD_LOG_LEVEL: ${dd_log_level}
+    USE_DOGSTATSD: ${dd_dogstatsd_enabled}
+    STATSD_METRIC_NAMESPACE: ${statsd_namespace}
+    DD_URL: ${custom_dd_url}
+    PROXY_HOST: ${proxy_host}
+    PROXY_PORT: ${proxy_port}
+    DD_APM_ENABLED: ${dd_apm_enabled}
+    # Evaluated by datadog-init script
+    DD_HOST_LABELS: ${host_labels}
+    DD_HOST_TAGS: ${host_tags}
+    DD_CONTAINER_LABELS: ${service_labels}
+    DD_SERVICE_DISCOVERY: ${service_discovery}
+    DD_SD_CONFIG_BACKEND: ${sd_config_backend}
+    DD_SD_BACKEND_HOST: ${sd_backend_host}
+    DD_SD_BACKEND_PORT: ${sd_backend_port}
+    DD_SD_TEMPLATE_DIR: ${sd_template_dir}
+    DD_CONSUL_TOKEN: ${dd_consul_token}
+    DD_CONSUL_SCHEME: ${dd_consul_scheme}
+    DD_CONSUL_VERIFY: ${dd_consul_verify}
+    DD_METADATA_HOSTNAME: rancher-metadata
+  volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    - /proc/:/host/proc/:ro
+    - ${cgroups_location}:/host/sys/fs/cgroup:ro
+  volumes_from:
+    - datadog-init
+  labels:
+    io.rancher.scheduler.global: "${global_service}"
+    io.rancher.sidekicks: "datadog-init"

--- a/templates/datadog/6/rancher-compose.yml
+++ b/templates/datadog/6/rancher-compose.yml
@@ -1,0 +1,168 @@
+.catalog:
+  name: "Datadog"
+  version: "1.1.1-11.0.5140"
+  description: "Real-time performance tracking and visualization of your container-based application deployment"
+  minimum_rancher_version: v1.2.0
+  questions:
+    - variable: "api_key"
+      label: "Datadog API Key"
+      description: |
+        Enter your Datadog API key.
+      required: true
+      type: "string"
+    - variable: "global_service"
+      label: "Global Service"
+      description: |
+        Enable this option to run a Datadog agent container on every host in the environment.
+      required: true
+      type: "boolean"
+      default: true
+    - variable: "host_labels"
+      label: "Export Host Labels as Tags"
+      description: |
+        Comma delimited list of host labels to export as Datadog host tags, e.g. 'region,zone'.
+      required: false
+      type: "string"
+    - variable: "service_labels"
+      label: "Export Service Labels as Tags"
+      description: |
+        Comma delimited list of service labels to export as Datadog metric tags.
+        'io.rancher.stack.name' and 'io.rancher.stack_service.name' are exported by default.
+      required: false
+      type: "string"
+    - variable: "host_tags"
+      label: "Global Host Tags"
+      description: |
+        Comma delimited list of host tags to apply to metrics, e.g. 'simple-tag-0,tag-key-1:tag-value-1'.
+      required: false
+      type: "string"
+    - variable: "dd_ec2_tags"
+      label: "Collect AWS EC2 Tags"
+      description: |
+        Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance).
+      required: true
+      type: "boolean"
+      default: false
+    - variable: cgroups_location
+      label: Cgroup directory location
+      description: |
+        Set this to '/cgroups/' if your hosts are running Amazon Linux AMIs.
+      required: true
+      type: enum
+      default: '/sys/fs/cgroup/'
+      options:
+        - '/sys/fs/cgroup/'
+        - '/cgroups/'
+    - variable: "dd_apm_enabled"
+      label: "Enable APM agent"
+      description: |
+        Enable the Datadog trace-agent along with the infrastructure agent, allowing the container to accept traces on 8126/tcp.
+        This will run the agent from the Debian based Datadog image instead of the Alpine based one. 
+      required: true
+      type: "boolean"
+      default: false
+    - variable: "service_discovery"
+      label: "Enable Service Discovery"
+      description: |
+        Collect metrics from supported applications running in Docker containers.
+      required: true
+      type: "boolean"
+      default: false
+    - variable: "sd_config_backend"
+      label: Service Discovery Configuration Backend
+      description: |
+        Choose a key/value store to use for looking up application configuration templates.
+        If none is provided only auto config templates will be used.
+      required: true
+      type: enum
+      default: none
+      options:
+        - none
+        - etcd
+        - consul
+    - variable: "sd_backend_host"
+      label: "Configuration Backend Host"
+      description: |
+        IP address or DNS name to use to connect to the configuration backend.
+      required: false
+      type: "string"
+    - variable: "sd_backend_port"
+      label: "Configuration Backend Port"
+      description: |
+        Port to use to connect to the configuration backend.
+      required: false
+      type: "int"
+    - variable: "sd_template_dir"
+      label: "Configuration Backend Template Path"
+      description: |
+        Specify a custom path where the agent should look for configuration templates in the backend.
+        The default is '/datadog/check_configs'.
+      required: false
+      type: "string"
+    - variable: "dd_consul_scheme"
+      label: "Consul Connection Scheme"
+      description: |
+        Scheme to use for requests to a Consul backend.
+      required: false
+      type: enum
+      default: http
+      options:
+        - http
+        - https
+    - variable: "dd_consul_verify"
+      label: "Verify Consul SSL Certificate"
+      description: |
+        Whether to verify the SSL certificate for HTTPS requests to a Consul backend.
+      required: false
+      type: "boolean"
+      default: true
+    - variable: "dd_consul_token"
+      label: "Consul ACL Token"
+      description: |
+        If the Consul backend uses ACL, specify a token granting read access to the configuration templates.
+      required: false
+      type: "string"
+    - variable: "dd_dogstatsd_enabled"
+      label: "Enable DogStatsD"
+      description: |
+        Enable a DogStatsD instance to run along with the infrastructure agent.
+      required: true
+      type: "boolean"
+      default: true
+    - variable: "statsd_namespace"
+      label: "StatsD Metric Namespace"
+      description: |
+        Optional namespace for aggregated StatsD metrics.
+      required: false
+      type: "string"
+    - variable: "custom_dd_url"
+      label: "Custom Datadog Intake URL"
+      description: |
+        Set a custom Intake URL to send Agent data to.
+      required: false
+      type: "string"
+    - variable: "dd_log_level"
+      label: "Agent log level"
+      description: |
+        Set the logging verbosity of the Datadog agent.
+      required: false
+      type: enum
+      default: INFO
+      options:
+        - CRITICAL
+        - ERROR
+        - WARNING
+        - INFO
+        - DEBUG
+    - variable: "proxy_host"
+      label: "Proxy Host"
+      description: |
+        Use a proxy to send Agent data to the Datadog servers.
+      required: false
+      type: "string"
+    - variable: "proxy_port"
+      label: "Proxy Port"
+      description: |
+        Use a proxy to send Agent data to the Datadog servers.
+      required: false
+      type: "string"

--- a/templates/datadog/config.yml
+++ b/templates/datadog/config.yml
@@ -1,7 +1,7 @@
 name: Datadog
 description: |
   Real-time performance tracking and visualization of your container-based application deployment
-version: 1.1.0-11.0.5123
+version: 1.1.1-11.0.5140
 category: Monitoring
 maintainer: "Jan Bruder <jan@rancher.com>"
 license: The MIT License


### PR DESCRIPTION
Updated to use Datadog agent 5.14.0 which: 
* Fixes Service Discovery that was broken due to Rancher 1.2 CNI changes: https://github.com/DataDog/dd-agent/commit/480420e50057167b9981aabe93dd129bed0b9460
* Tags container metrics with Rancher stack and service name out of the box: https://github.com/DataDog/integrations-core/pull/282
