### PR TITLE
update dnsupdate to use custom dns record

### DIFF
--- a/infra-templates/dnsupdate-rfc2136/4/README.md
+++ b/infra-templates/dnsupdate-rfc2136/4/README.md
@@ -1,0 +1,52 @@
+## DNS Update (RFC2136)
+
+Rancher External DNS service powered by any RFC2136 compatible DNS server
+
+#### Changelog
+
+##### v0.6.2
+
+* Adds support for disabling/enforcing external DNS on the host and service level using labels
+* Adds support for insecure DNS Updates
+* Fixes an issue with lingering TCP keep-alive connections to the Rancher Metadata service
+
+#### Usage
+
+##### Upgrade Notes
+While upgrading from a version lower than v0.6.0 the TTL configuration value should not be changed. You may change it once the upgrade has been completed.
+
+##### Limitation when running the service on multiple Rancher servers
+
+When running multiple instances of the External DNS service configured to use the same domain name, then only one of them can run in the "Default" environment of a Rancher server instance.
+
+##### Supported host labels
+
+`io.rancher.host.external_dns_ip`     
+Override the IP address used in DNS records for containers running on the host. Defaults to the IP address the host is registered with in Rancher.
+      
+`io.rancher.host.external_dns`    
+Accepts 'true' (default) or 'false'    
+When this is set to 'false' no DNS records will ever be created for containers running on this host.
+
+##### Supported service labels
+
+`io.rancher.service.external_dns`     
+Accepts 'always', 'never' or 'auto' (default)  
+- `always`: Always create DNS records for this service
+- `never`: Never create DNS records for this service
+- `auto`: Create DNS records for this service if it exposes ports on the host
+     
+##### Custom DNS name template
+
+By default DNS entries are named `<service>.<stack>.<environment>.<domain>`.    
+You can specify a custom name template used to construct the subdomain part (left of the domain/zone name) of the DNS records. The following placeholders are supported:
+
+* `%{{service_name}}`
+* `%{{stack_name}}`
+* `%{{environment_name}}`
+
+**Example:**
+
+`%{{stack_name}}-%{{service_name}}.statictext`
+
+Make sure to only use characters in static text and separators that your provider allows in DNS names.

--- a/infra-templates/dnsupdate-rfc2136/4/README.md
+++ b/infra-templates/dnsupdate-rfc2136/4/README.md
@@ -36,6 +36,14 @@ Accepts 'always', 'never' or 'auto' (default)
 - `never`: Never create DNS records for this service
 - `auto`: Create DNS records for this service if it exposes ports on the host
      
+
+`io.rancher.service.external_dns_name_template`
+Accepts valid DNS name template
+
+By default DNS entries are named based on default template defined on dnsupdate service.
+You can customize it per service by assigning `io.rancher.service.external_dns_name_template` label to each service.
+dnsupdate will use this template instead of default one when creating dns record for related service.
+
 ##### Custom DNS name template
 
 By default DNS entries are named `<service>.<stack>.<environment>.<domain>`.    

--- a/infra-templates/dnsupdate-rfc2136/4/docker-compose.yml
+++ b/infra-templates/dnsupdate-rfc2136/4/docker-compose.yml
@@ -1,0 +1,17 @@
+rfc2136dns:
+  image: rancher/external-dns:v0.6.2
+  command: -provider=rfc2136
+  expose:
+   - 1000
+  environment:
+    RFC2136_HOST: ${RFC2136_HOST}
+    RFC2136_PORT: ${RFC2136_PORT}
+    RFC2136_TSIG_KEYNAME: ${RFC2136_TSIG_KEYNAME}
+    RFC2136_TSIG_SECRET: ${RFC2136_TSIG_SECRET}
+    RFC2136_INSECURE: ${RFC2136_INSECURE}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    NAME_TEMPLATE: ${NAME_TEMPLATE}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/infra-templates/dnsupdate-rfc2136/4/docker-compose.yml
+++ b/infra-templates/dnsupdate-rfc2136/4/docker-compose.yml
@@ -1,5 +1,5 @@
 rfc2136dns:
-  image: rancher/external-dns:v0.6.2
+  image: rancher/external-dns:v0.7.2
   command: -provider=rfc2136
   expose:
    - 1000

--- a/infra-templates/dnsupdate-rfc2136/4/rancher-compose.yml
+++ b/infra-templates/dnsupdate-rfc2136/4/rancher-compose.yml
@@ -1,0 +1,63 @@
+# notemplating
+.catalog:
+  name: "DNS Update (RFC2136)"
+  version: "v0.6.2-rancher2"
+  description: "Rancher External DNS service powered by any RFC2136 compatible DNS server. Requires Rancher version v1.1.0"
+  minimum_rancher_version: v1.6.0-rc1
+  questions:
+    - variable: "RFC2136_HOST"
+      label: "DNS Server IP"
+      description: "Server IP or Hostname"
+      type: "string"
+      required: true
+    - variable: "RFC2136_PORT"
+      label: "DNS Server Port"
+      description: "Server port"
+      type: "string"
+      required: true
+      default: "53"
+    - variable: "RFC2136_INSECURE"
+      description: "Disables TSIG authentication for DNS Update requests"
+      label: "Insecure DNS Update"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "RFC2136_TSIG_KEYNAME"
+      label: "TSIG Key Name"
+      description: "Name of the TSIG key used for authenticating with the DNS server"
+      type: "string"
+      required: false
+    - variable: "RFC2136_TSIG_SECRET"
+      label: "TSIG Key"
+      description: "TSIG secret key used for authenticating with the DNS server (HMAC-MD5, base64 encoded)"
+      type: "string"
+      required: false
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds"
+      type: "int"
+      default: 60
+      required: false
+    - variable: "ROOT_DOMAIN"
+      label: "Zone name"
+      description: "The name of an existing zone in which to create the records."
+      type: "string"
+      required: true
+    - variable: "NAME_TEMPLATE"
+      label: "DNS Name Template"
+      description: |
+        Name template used to construct the subdomain part (left of the zone/domain name) of the DNS record names.
+        Supported placeholders: %{{service_name}}, %{{stack_name}}, %{{environment_name}}.
+        By default DNS entries will be named '<service>.<stack>.<environment>.<domain>'.
+      type: "string"
+      default: "%{{service_name}}.%{{stack_name}}.%{{environment_name}}"
+      required: false
+
+rfc2136dns:
+  health_check:
+    port: 1000
+    interval: 5000
+    unhealthy_threshold: 3
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/infra-templates/dnsupdate-rfc2136/4/rancher-compose.yml
+++ b/infra-templates/dnsupdate-rfc2136/4/rancher-compose.yml
@@ -1,7 +1,7 @@
 # notemplating
 .catalog:
   name: "DNS Update (RFC2136)"
-  version: "v0.6.2-rancher2"
+  version: "v0.7.2-rancher1"
   description: "Rancher External DNS service powered by any RFC2136 compatible DNS server. Requires Rancher version v1.1.0"
   minimum_rancher_version: v1.6.0-rc1
   questions:

--- a/infra-templates/dnsupdate-rfc2136/config.yml
+++ b/infra-templates/dnsupdate-rfc2136/config.yml
@@ -1,7 +1,7 @@
 name: DNS Update (RFC2136)
 description: |
   Rancher External DNS service powered by any RFC2136 compatible DNS
-version: v0.6.2-rancher2
+version: v0.7.2-rancher1
 category: External DNS
 labels:
   io.rancher.orchestration.supported: 'cattle,mesos,swarm,kubernetes'


### PR DESCRIPTION
By default DNS entries are named based on default template defined on dnsupdate service.
You can customize it per service by assigning `io.rancher.service.external_dns_name_template` label to each service.
dnsupdate will use this template instead of default one when creating dns record for related service.
