### PR TITLE
Upgrade traefik package to v1.3.5

### DIFF
--- a/templates/traefik/7/docker-compose.yml.tpl
+++ b/templates/traefik/7/docker-compose.yml.tpl
@@ -42,7 +42,7 @@ traefik-conf:
     io.rancher.container.start_once: 'true'
   tty: true
   log_opt: {}
-  image: rawmind/rancher-traefik:1.3.3
+  image: rawmind/rancher-traefik:1.3.3-1
   net: none
   volumes:
     - /opt/tools

--- a/templates/traefik/8/docker-compose.yml.tpl
+++ b/templates/traefik/8/docker-compose.yml.tpl
@@ -42,7 +42,7 @@ traefik-conf:
     io.rancher.container.start_once: 'true'
   tty: true
   log_opt: {}
-  image: rawmind/rancher-traefik:1.3.3
+  image: rawmind/rancher-traefik:1.3.3-1
   net: none
   volumes:
     - /opt/tools

--- a/templates/traefik/9/README.md
+++ b/templates/traefik/9/README.md
@@ -1,0 +1,79 @@
+# Traefik active load balancer (Experimental)
+
+### Info:
+
+ This template deploys traefik active load balancers on top of Rancher. The configuration is generated and updated with confd from Rancher metadata. 
+ It would be deployed in hosts with label traefik_lb=true.
+
+### Config:
+
+- host_label = "traefik_lb=true" # Host label where to run traefik service.
+- http_port = 8080  # Port exposed to get access to the published services.
+- https_port = 8443  # Port exposed to get secured access to the published services.
+- admin_port = 8000  # Port exposed to get admin access to the traefik service.
+- https_enable = <false | true | only>
+  - false: Enable http enpoints and disable https ones.
+  - true: Enable http and https endpoints.
+  - only: Enable https endpoints and redirect http to https.
+- acme_enable = false               # Enable/Disable acme traefik support.
+- acme_email = "test@traefik.io"    # acme user email
+- acme_ondemand = true              # acme ondemand parameter.
+- acme_onhostrule = true            # acme onHostRule parameter.
+- ssl_key # Paste your ssl key. *Required if you enable https
+- ssl_crt # Paste your ssl crt. *Required if you enable https
+- insecure_skip = false	  # Enable InsecureSkipVerify param.
+- refresh_interval = 10s  # Interval to refresh traefik rules.toml from rancher-metadata.
+
+NOTE: If you enable acme support, additional sidekick will be created for acme persistance.
+
+### Service configuration labels:
+
+Traefik labels has to be added in your services, in order to get included in traefik dynamic config.
+
+- traefik.enable = <true | false> 
+  - true: the service will be published as *service_name.stack_name.traefik_domain*
+  - stack: the service will be published as *stack_name.traefik_domain*. WARNING: You could have collisions inside services within your stack
+  - false: the service will not be published
+- traefik.priority = <priority>     	  	# Override for frontend priority. 5 by default
+- traefik.protocol = < http | https	>		# Override the default http protocol
+- traefik.sticky = < true | false	>		# Enable/disable sticky sessions to the backend
+- traefik.alias = < alias >					# Alternate names to route rule. Multiple values separated by ",". traefik.domain is appended. WARNING: You could have collisions BE CAREFULL
+- traefik.alias.fqdn = < alias fqdn >					# Alternate names to route rule. Multiple values separated by ",". traefik.domain must be defined but is not appended here.
+- traefik.domain = < domain.name >			# Domain names to route rules. Multiple domains separated by ","
+- traefik.domain.regexp = < domain.regexp > # Domain name regexp rule. Multiple domains separated by ","
+- traefik.port = < port >           # Port to expose throught traefik  
+- traefik.acme = < true | false >   # Enable/disable ACME traefik feature
+- traefik.path = < path >                   # Path rule. Multiple values separated by ","
+- traefik.path.strip = < path >             # Path strip rule. Multiple values separated by ","
+- traefik.path.prefix = < path >            # Path prefix rule. Multiple values separated by ","
+- traefik.path.prefix.strip = < path >      # Path prefix strip rule. Multiple values separated by ","
+
+Details for configuring the traefik rules can be found at: https://docs.traefik.io/basics/#frontends
+
+WARNING: Only services with healthy state are added to traefik, so health checks are mandatory.
+
+### Usage:
+
+ Select Traefik from catalog. 
+ 
+ Set the params.
+
+ Click deploy.
+
+ Services will be accessed throught hosts ip's whith $host_label: 
+
+ - http://${service_name}.${stack_name}.${traefik.domain}:${http_port}
+ - https://${service_name}.${stack_name}.${traefik.domain}:${https_port}
+ 
+ or 
+ 
+ - http://${stack_name}.${traefik.domain}:${http_port}
+ - https://${stack_name}.${traefik.domain}:${https_port}
+
+ If you set traefik.alias you service could also be acceses through
+
+ - http://${traefik.alias}.${traefik.domain}:${http_port}
+ - https://${traefik.alias}.${traefik.domain}:${https_port}
+
+Note: To access the services, you need to create A or CNAMES dns entries for every one. 
+

--- a/templates/traefik/9/docker-compose.yml.tpl
+++ b/templates/traefik/9/docker-compose.yml.tpl
@@ -1,0 +1,67 @@
+version: '2'
+services:
+  traefik:
+    ports:
+    - ${admin_port}:8000/tcp
+    - ${http_port}:${http_port}/tcp
+    - ${https_port}:${https_port}/tcp
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.sidekicks: traefik-conf
+        {{- if eq .Values.acme_enable "true" -}}
+          ,traefik-acme
+        {{- end}}
+      io.rancher.container.hostname_override: container_name
+    image: rawmind/alpine-traefik:1.3.5
+    environment:
+    - CONF_INTERVAL=${refresh_interval}
+    - TRAEFIK_HTTP_PORT=${http_port}
+    - TRAEFIK_HTTPS_PORT=${https_port}
+    - TRAEFIK_HTTPS_ENABLE=${https_enable}
+  {{- if eq .Values.acme_enable "true"}}
+    - TRAEFIK_ACME_ENABLE=${acme_enable}
+    - TRAEFIK_ACME_EMAIL=${acme_email}
+    - TRAEFIK_ACME_ONDEMAND=${acme_ondemand}
+    - TRAEFIK_ACME_ONHOSTRULE=${acme_onhostrule}
+  {{- end}}
+    - TRAEFIK_INSECURE_SKIP=${insecure_skip}
+    volumes_from:
+    - traefik-conf
+  {{- if eq .Values.acme_enable "true"}}
+    - traefik-acme
+  {{- end}}
+  traefik-conf:
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.start_once: 'true'
+    image: rawmind/rancher-traefik:1.3.3-1
+    network_mode: none
+    volumes:
+      - tools-volume:/opt/tools
+  {{- if eq .Values.acme_enable "true"}}
+  traefik-acme:
+    network_mode: none
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.start_once: true
+    environment:
+      - SERVICE_UID=10001
+      - SERVICE_GID=10001
+      - SERVICE_VOLUME=/opt/traefik/acme
+    volumes:
+      - ${VOLUME_NAME}:/opt/traefik/acme
+    image: rawmind/alpine-volume:0.0.2-1
+  {{- end}}
+volumes:
+  tools-volume:
+    driver: local
+    per_container: true
+  {{- if eq .Values.acme_enable "true"}}
+  ${VOLUME_NAME}:
+    driver: ${VOLUME_DRIVER}
+  {{- end}}

--- a/templates/traefik/9/rancher-compose.yml
+++ b/templates/traefik/9/rancher-compose.yml
@@ -1,0 +1,126 @@
+version: '2'
+catalog:
+  name: traefik
+  version: v1.3.5-rancher1
+  description: |
+    (Experimental) Traefik load balancer.
+  minimum_rancher_version: v0.59.0
+  maintainer: "Raul Sanchez <rawmind@gmail.com>"
+  uuid: traefik-0
+  questions:
+    - variable: "host_label"
+      description: "Host label where to run traefik service."
+      label: "Host label:"
+      required: true
+      default: "traefik_lb=true" 
+      type: "string"
+    - variable: "http_port"
+      description: "Traefik http public port to listen."
+      label: "Http port:"
+      required: true
+      default: 8080
+      type: "int"
+    - variable: "https_port"
+      description: "Traefik https public port to listen."
+      label: "Https port:"
+      required: true
+      default: 8443
+      type: "int"
+    - variable: "admin_port"
+      description: "Traefik admin public port to listen."
+      label: "Admin port:"
+      required: true
+      default: 8000 
+      type: "int"
+    - variable: "https_enable"
+      label: "Enable HTTPS:"
+      description: |
+        Enable https working mode. If you activate, you need to fill SSL key and SSL crt in order to work.
+      default: false
+      required: true
+      type: enum
+      options:
+        - false
+        - true
+        - only
+    - variable: "acme_enable"
+      description: "Enable acme support on traefik."
+      label: "Enable ACME:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "acme_email"
+      description: "ACME user email."
+      label: "ACME email:"
+      required: true
+      default: "test@traefik.io" 
+      type: "string"
+    - variable: "acme_ondemand"
+      description: "Enable acme ondemand."
+      label: "ACME ondemand:"
+      required: true
+      default: true 
+      type: "boolean"
+    - variable: "acme_onhostrule"
+      description: "Enable acme onHostRule."
+      label: "ACME onHostRule:"
+      required: true
+      default: true 
+      type: "boolean"
+    - variable: "ssl_key"
+      description: "SSL key to secure the service. *Required if you enable https"
+      label: "SSL key"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "ssl_crt"
+      description: "SSL cert to secure the service. *Required if you enable https"
+      label: "SSL crt"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "insecure_skip"
+      description: "Enable InsecureSkipVerify param."
+      label: "InsecureSkipVerify:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "refresh_interval"
+      description: "Interval to poll/apply configuration changes." 
+      label: "Refresh Interval (s):"
+      required: true
+      default: 10 
+      type: "int"
+    - variable: "VOLUME_NAME"
+      description: "The volume name shared to store ACME certs"
+      label: "ACME Volume Name"
+      required: true
+      default: "TRAEFIK"
+      type: "string"
+    - variable: "VOLUME_DRIVER"
+      description: "The volume driver shared to store ACME certs"
+      label: "ACME Volume Driver"
+      required: true
+      default: "rancher-nfs"
+      type: enum
+      options: # List of options if using type of `enum`
+        - local
+        - rancher-nfs
+        - rancher-efs
+        - rancher-ebs
+services:
+  traefik:
+    retain_ip: true
+    health_check:
+      port: 8000
+      interval: 5000
+      unhealthy_threshold: 3
+      request_line: 'GET /dashboard/# HTTP/1.0'
+      healthy_threshold: 2
+      response_timeout: 5000
+    metadata:
+      traefik:
+        ssl_key: |
+          ${ssl_key}
+        ssl_crt: |
+          ${ssl_crt}

--- a/templates/traefik/config.yml
+++ b/templates/traefik/config.yml
@@ -1,7 +1,7 @@
 name: Traefik
 description: |
   (Experimental) Traefik active load balancer
-version: v1.3.3-rancher2
+version: v1.3.5-rancher1
 category: Load Balancing
 maintainer: "Raul Sanchez <rawmind@gmail.com>"
 minimum_rancher_version: v0.59.0


### PR DESCRIPTION
- Upgraded traefik to v1.3.5
- Updated to compose version 2 notation.
- Some bugfixes in rancher-traefik:1.3.3-1