### PR TITLE
gitlab-ce to 9.4.5 and gitlab-runner to 9.4.2 added as new version

### DIFF
--- a/templates/gitlab-multi-runner/2/docker-compose.yml.tpl
+++ b/templates/gitlab-multi-runner/2/docker-compose.yml.tpl
@@ -1,0 +1,47 @@
+version: '2'
+
+services:
+
+  gitlab-runner-config:
+    image: gitlab/gitlab-runner:alpine-v9.4.1
+    stdin_open: true
+    volumes:
+    - /etc/gitlab-runner/
+    tty: true
+    command:
+    - register
+    - -n
+    - --url
+    - ${GITLAB_URL}
+    - --registration-token
+    - ${GITLAB_TOKEN}
+    - --tag-list
+    - ${GITLAB_TAGS}
+    - --executor
+    - docker
+    - --description
+    - Rancher Docker Runner
+    - --docker-image
+    - docker:latest
+    - --docker-volumes
+    - /var/run/docker.sock:/var/run/docker.sock
+    - --docker-privileged
+    labels:
+      io.rancher.container.start_once: 'true'
+
+  gitlab-runner:
+    image: gitlab/gitlab-runner:alpine-v9.4.1
+    stdin_open: true
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    tty: true
+    volumes_from:
+    - gitlab-runner-config
+    command:
+    - run
+    labels:
+      io.rancher.sidekicks: gitlab-runner-config
+      io.rancher.scheduler.global: 'true'
+    {{- if ne .Values.host_label ""}}
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+    {{- end}}

--- a/templates/gitlab-multi-runner/2/docker-compose.yml.tpl
+++ b/templates/gitlab-multi-runner/2/docker-compose.yml.tpl
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gitlab-runner-config:
-    image: gitlab/gitlab-runner:alpine-v9.4.1
+    image: gitlab/gitlab-runner:alpine-v9.4.2
     stdin_open: true
     volumes:
     - /etc/gitlab-runner/
@@ -30,7 +30,7 @@ services:
       io.rancher.container.start_once: 'true'
 
   gitlab-runner:
-    image: gitlab/gitlab-runner:alpine-v9.4.1
+    image: gitlab/gitlab-runner:alpine-v9.4.2
     stdin_open: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/templates/gitlab-multi-runner/2/rancher-compose.yml
+++ b/templates/gitlab-multi-runner/2/rancher-compose.yml
@@ -1,0 +1,45 @@
+version: '2'
+
+catalog:
+  name: "gitlab-multi-runner"
+  version: "9.4.2"
+  description: "a Gitlab pipelines multi-runner, that will spawn privates runners in your infra."
+  minimum_rancher_version: v1.5.0
+  # maximum_rancher_version:
+  # upgrade_from: # The previous versions that this template can be upgraded from
+  questions:
+    - variable: "GITLAB_URL"
+      label: "Gitlab Url"
+      description: "Url to your Gitlab CI endpoint"
+      type: "string"
+      default: "https://gitlab.com/ci"
+      required: true
+
+    - variable: "GITLAB_TOKEN"
+      label: "Gitlab Token"
+      description: "Token provided in you project settings"
+      type: "string"
+      default: "xxxxxxxxxxxxxxxxxxxx"
+      required: true
+
+    - variable: "GITLAB_TAGS"
+      label: "Gitlab Tags"
+      description: "Tags to apply"
+      type: "string"
+      default: "dev"
+      required: false
+
+    - variable: "host_label"
+      label: "Host with Label to deploy gitlab-runner on"
+      description: |
+        Host label to use as gitlab-runner 'value' tag.
+        Example: 'gitlab-runner=true'
+      type: "string"
+      default: ""
+      required: false
+
+services:
+  gitlab-runner-config:
+    start_on_create: true
+  gitlab-runner:
+    start_on_create: true

--- a/templates/gitlab-multi-runner/config.yml
+++ b/templates/gitlab-multi-runner/config.yml
@@ -1,5 +1,5 @@
 name: gitlab-multi-runner
 description: |
   a Gitlab pipelines multi-runner, that will spawn privates runners in your infra.
-version: 9.4.1
+version: 9.4.2
 category: Continuous Integration

--- a/templates/gitlab/2/README.md
+++ b/templates/gitlab/2/README.md
@@ -1,0 +1,9 @@
+# GitLab CE
+
+GitLab CE is a free alternative to GitHub
+
+Stack based on official GitLab version: latest
+
+https://hub.docker.com/r/gitlab/gitlab-ce/
+
+

--- a/templates/gitlab/2/docker-compose.yml
+++ b/templates/gitlab/2/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '2'
+volumes:
+  gitlab-app-data:
+    driver: ${volumedriver}
+  gitlab-log-data:
+    driver: ${volumedriver}
+  gitlab-conf-files:
+    driver: ${volumedriver}
+
+services:
+  gitlab-server:
+    ports:
+      - ${ssh_port}:22/tcp
+      - ${http_port}:80/tcp
+      - ${https_port}:443/tcp
+    labels:
+      io.rancher.container.hostname_override: container_name
+    image: gitlab/gitlab-ce:9.4.5-ce.0
+    volumes:
+      - gitlab-app-data:/var/opt/gitlab
+      - gitlab-log-data:/var/log/gitlab
+      - gitlab-conf-files:/etc/gitlab
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url '${gitlab_omnipus_prefix}${gitlab_hostname}'
+        registry_external_url '${gitlab_omnipus_prefix}${registry_gitlab_hostname}'

--- a/templates/gitlab/2/rancher-compose.yml
+++ b/templates/gitlab/2/rancher-compose.yml
@@ -1,0 +1,69 @@
+.catalog:
+  name: Gitlab Community
+  version: 9.4.5-ce.0
+  description: |
+    Gitlab CE is a free GitHub alternative
+  minimum_rancher_version: v0.56.0
+  maintainer: "Alexis Ducastel <alexis@ducastel.net>"
+  uuid: gitlab-0
+  questions:
+    - variable: "gitlab_hostname"
+      description: "Gitlab hostname (without uri scheme http:// or https://)"
+      label: "Hostname:"
+      required: true
+      default: "git.example.com"
+      type: "string"
+    - variable: "registry_gitlab_hostname"
+      description: "Registry Gitlab hostname (without uri scheme http:// or https://)"
+      label: "Registry hostname:"
+      required: true
+      default: "registry.example.com"
+      type: "string"
+    - variable: "gitlab_omnipus_prefix"
+      label: "Gitlab external_url prefix:"
+      description: |
+        This is needed for the docker-compose file to set the correct external_url
+      default: 'http://'
+      required: true
+      type: "enum"
+      options:
+        - 'http://'
+        - 'https://'
+    - variable: "http_port"
+      description: "HTTP port to expose on host. Will be used to bind TCP"
+      label: "HTTP port:"
+      required: true
+      default: 80
+      type: "int"
+    - variable: "https_port"
+      description: "HTTPS port to expose on host. Will be used to bind TCP"
+      label: "HTTPS port:"
+      required: true
+      default: 443
+      type: "int"
+    - variable: "ssh_port"
+      description: "SSH port to expose on host. Will be used to bind TCP"
+      label: "SSH port:"
+      required: true
+      default: 22
+      type: "int"
+    - variable: "volumedriver"
+      description: "Choose the Volume Driver being used.(Option: local or rancher-nfs)"
+      label: "Volume Driver:"
+      required: true
+      default: local
+      type: "enum"
+      options:
+        - local
+        - rancher-nfs
+
+gitlab-server:
+  scale: 1
+  retain_ip: true
+  health_check:
+    port: 80
+    interval: 30000
+    unhealthy_threshold: 3
+    strategy: recreate
+    response_timeout: 3000
+    healthy_threshold: 2

--- a/templates/gitlab/config.yml
+++ b/templates/gitlab/config.yml
@@ -1,5 +1,5 @@
 name: Gitlab Community
 description: |
   Gitlab CE is a free GitHub alternative
-version: 9.4.2-ce.0
+version: 9.4.5-ce.0
 category: Versioning


### PR DESCRIPTION
We updated our running gitlab-ce to 9.4.5 and gitlab-runner to 9.4.2. Push to private registry works perfectly now!


