### PR TITLE
add gitlab latest image version and fix ssh param bug in omnibus config

### DIFF
--- a/templates/gitlab/3/README.md
+++ b/templates/gitlab/3/README.md
@@ -1,0 +1,9 @@
+# GitLab CE
+
+GitLab CE is a free alternative to GitHub
+
+Stack based on official GitLab version: latest
+
+https://hub.docker.com/r/gitlab/gitlab-ce/
+
+

--- a/templates/gitlab/3/docker-compose.yml
+++ b/templates/gitlab/3/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '2'
+volumes:
+  gitlab-app-data:
+    driver: ${volumedriver}
+  gitlab-log-data:
+    driver: ${volumedriver}
+  gitlab-conf-files:
+    driver: ${volumedriver}
+
+services:
+  gitlab-server:
+    ports:
+      - ${ssh_port}:22/tcp
+      - ${http_port}:80/tcp
+      - ${https_port}:443/tcp
+    labels:
+      io.rancher.container.hostname_override: container_name
+    image: gitlab/gitlab-ce:9.5.1-ce.0
+    volumes:
+      - gitlab-app-data:/var/opt/gitlab
+      - gitlab-log-data:/var/log/gitlab
+      - gitlab-conf-files:/etc/gitlab
+    environment:
+      GITLAB_OMNIBUS_CONFIG: |
+        external_url '${gitlab_omnipus_prefix}${gitlab_hostname}'
+        registry_external_url '${gitlab_omnipus_prefix}${registry_gitlab_hostname}'
+        gitlab_rails['gitlab_shell_ssh_port'] = ${ssh_port}

--- a/templates/gitlab/3/rancher-compose.yml
+++ b/templates/gitlab/3/rancher-compose.yml
@@ -1,0 +1,69 @@
+.catalog:
+  name: Gitlab Community
+  version: 9.5.1-ce.0
+  description: |
+    Gitlab CE is a free GitHub alternative
+  minimum_rancher_version: v0.56.0
+  maintainer: "Alexis Ducastel <alexis@ducastel.net>"
+  uuid: gitlab-0
+  questions:
+    - variable: "gitlab_hostname"
+      description: "Gitlab hostname (without uri scheme http:// or https://)"
+      label: "Hostname:"
+      required: true
+      default: "git.example.com"
+      type: "string"
+    - variable: "registry_gitlab_hostname"
+      description: "Registry Gitlab hostname (without uri scheme http:// or https://)"
+      label: "Registry hostname:"
+      required: true
+      default: "registry.example.com"
+      type: "string"
+    - variable: "gitlab_omnipus_prefix"
+      label: "Gitlab external_url prefix:"
+      description: |
+        This is needed for the docker-compose file to set the correct external_url
+      default: 'http://'
+      required: true
+      type: "enum"
+      options:
+        - 'http://'
+        - 'https://'
+    - variable: "http_port"
+      description: "HTTP port to expose on host. Will be used to bind TCP"
+      label: "HTTP port:"
+      required: true
+      default: 80
+      type: "int"
+    - variable: "https_port"
+      description: "HTTPS port to expose on host. Will be used to bind TCP"
+      label: "HTTPS port:"
+      required: true
+      default: 443
+      type: "int"
+    - variable: "ssh_port"
+      description: "SSH port to expose on host. Will be used to bind TCP"
+      label: "SSH port:"
+      required: true
+      default: 22
+      type: "int"
+    - variable: "volumedriver"
+      description: "Choose the Volume Driver being used.(Option: local or rancher-nfs)"
+      label: "Volume Driver:"
+      required: true
+      default: local
+      type: "enum"
+      options:
+        - local
+        - rancher-nfs
+
+gitlab-server:
+  scale: 1
+  retain_ip: true
+  health_check:
+    port: 80
+    interval: 30000
+    unhealthy_threshold: 3
+    strategy: recreate
+    response_timeout: 3000
+    healthy_threshold: 2

--- a/templates/gitlab/config.yml
+++ b/templates/gitlab/config.yml
@@ -1,5 +1,5 @@
 name: Gitlab Community
 description: |
   Gitlab CE is a free GitHub alternative
-version: 9.4.5-ce.0
+version: 9.5.1-ce.0
 category: Versioning


### PR DESCRIPTION
update GitLab catalog about the below.
* add gitlab latest docker image version(9.5.1-ce.0)
* add gitlab_rails['gitlab_shell_ssh_port'] parameter in omnibus config