### PR TITLE
Gogs: Fix data persistence

### DIFF
--- a/templates/gogs/0/docker-compose.yml.tpl
+++ b/templates/gogs/0/docker-compose.yml.tpl
@@ -3,7 +3,7 @@ services:
   gogs:
     image: gogs/gogs:0.11.19
     volumes:
-      - gogs-data:/data/gogs
+      - gogs-data:/data
 {{- if ne .Values.db_link ""}}
     external_links:
       - ${db_link}:db


### PR DESCRIPTION
Gogs stores all git repositories in /data/git/gogs-repositories, so they are lost after each restart. This results in error 500 when you try to open the repository.

Also you can find generated SSH keys in /data/ssh that are being lost too.

This commit changes the gogs-data volume to point to /data to achieve data persistence and to avoid creation of dangling volumes.

Source: [Dockerfile](https://hub.docker.com/r/gogs/gogs/~/dockerfile/)

Note: I could just add separate volumes for /data/ssh and /data/git to save backward compatibility, but it would produce many dangling volumes out of /data. Tell me if it's not a problem and I will create a new pull request.