### PR TITLE
Fix LetsEncrypt: add missing environment variables for Aurora and NS1

### DIFF
--- a/templates/letsencrypt/4/docker-compose.yml.tpl
+++ b/templates/letsencrypt/4/docker-compose.yml.tpl
@@ -3,44 +3,49 @@ services:
   letsencrypt:
     image: janeczku/rancher-letsencrypt:v0.5.0
     environment:
-      EULA: ${EULA}
-      API_VERSION: ${API_VERSION}
-      CERT_NAME: ${CERT_NAME}
-      EMAIL: ${EMAIL}
-      DOMAINS: ${DOMAINS}
-      DNS_RESOLVERS: ${DNS_RESOLVERS}
-      PUBLIC_KEY_TYPE: ${PUBLIC_KEY_TYPE}
-      RENEWAL_TIME: ${RENEWAL_TIME}
-      RENEWAL_PERIOD_DAYS: ${RENEWAL_PERIOD_DAYS}
-      PROVIDER: ${PROVIDER}
-      CLOUDFLARE_EMAIL: ${CLOUDFLARE_EMAIL}
-      CLOUDFLARE_KEY: ${CLOUDFLARE_KEY}
-      DO_ACCESS_TOKEN: ${DO_ACCESS_TOKEN}
-      AWS_ACCESS_KEY: ${AWS_ACCESS_KEY}
-      AWS_SECRET_KEY: ${AWS_SECRET_KEY}
-      DNSIMPLE_EMAIL: ${DNSIMPLE_EMAIL}
-      DNSIMPLE_KEY: ${DNSIMPLE_KEY}
-      DYN_CUSTOMER_NAME: ${DYN_CUSTOMER_NAME}
-      DYN_USER_NAME: ${DYN_USER_NAME}
-      DYN_PASSWORD: ${DYN_PASSWORD}
-      VULTR_API_KEY: ${VULTR_API_KEY}
-      OVH_APPLICATION_KEY: ${OVH_APPLICATION_KEY}
-      OVH_APPLICATION_SECRET: ${OVH_APPLICATION_SECRET}
-      OVH_CONSUMER_KEY: ${OVH_CONSUMER_KEY}
-      GANDI_API_KEY: ${GANDI_API_KEY}
-      AZURE_CLIENT_ID: ${AZURE_CLIENT_ID}
-      AZURE_CLIENT_SECRET: ${AZURE_CLIENT_SECRET}
-      AZURE_SUBSCRIPTION_ID: ${AZURE_SUBSCRIPTION_ID}
-      AZURE_TENANT_ID: ${AZURE_TENANT_ID}
-      AZURE_RESOURCE_GROUP: ${AZURE_RESOURCE_GROUP}
+      EULA: "${EULA}"
+      API_VERSION: "${API_VERSION}"
+      CERT_NAME: "${CERT_NAME}"
+      EMAIL: "${EMAIL}"
+      DOMAINS: "${DOMAINS}"
+      PUBLIC_KEY_TYPE: "${PUBLIC_KEY_TYPE}"
+      RENEWAL_TIME: "${RENEWAL_TIME}"
+      PROVIDER: "${PROVIDER}"
+      DNS_RESOLVERS: "${DNS_RESOLVERS}"
+      RENEWAL_PERIOD_DAYS: "${RENEWAL_PERIOD_DAYS}"
+      RUN_ONCE: "${RUN_ONCE}"
+      CLOUDFLARE_EMAIL: "${CLOUDFLARE_EMAIL}"
+      CLOUDFLARE_KEY: "${CLOUDFLARE_KEY}"
+      DO_ACCESS_TOKEN: "${DO_ACCESS_TOKEN}"
+      AWS_ACCESS_KEY: "${AWS_ACCESS_KEY}"
+      AWS_SECRET_KEY: "${AWS_SECRET_KEY}"
+      DNSIMPLE_EMAIL: "${DNSIMPLE_EMAIL}"
+      DNSIMPLE_KEY: "${DNSIMPLE_KEY}"
+      DYN_CUSTOMER_NAME: "${DYN_CUSTOMER_NAME}"
+      DYN_USER_NAME: "${DYN_USER_NAME}"
+      DYN_PASSWORD: "${DYN_PASSWORD}"
+      VULTR_API_KEY: "${VULTR_API_KEY}"
+      OVH_APPLICATION_KEY: "${OVH_APPLICATION_KEY}"
+      OVH_APPLICATION_SECRET: "${OVH_APPLICATION_SECRET}"
+      OVH_CONSUMER_KEY: "${OVH_CONSUMER_KEY}"
+      GANDI_API_KEY: "${GANDI_API_KEY}"
+      AZURE_CLIENT_ID: "${AZURE_CLIENT_ID}"
+      AZURE_CLIENT_SECRET: "${AZURE_CLIENT_SECRET}"
+      AZURE_SUBSCRIPTION_ID: "${AZURE_SUBSCRIPTION_ID}"
+      AZURE_TENANT_ID: "${AZURE_TENANT_ID}"
+      AZURE_RESOURCE_GROUP: "${AZURE_RESOURCE_GROUP}"
+      AURORA_USER_ID: "${AURORA_USER_ID}"
+      AURORA_KEY: "${AURORA_KEY}"
+      AURORA_ENDPOINT: "${AURORA_ENDPOINT}"
+      NS1_API_KEY: "${NS1_API_KEY}"
     volumes:
       - /var/lib/rancher:/var/lib/rancher
       {{- if .Values.VOLUME_NAME}}
       - {{.Values.VOLUME_NAME}}:/etc/letsencrypt
       {{- end }}
     labels:
-      io.rancher.container.create_agent: 'true'
-      io.rancher.container.agent.role: 'environment'
+      io.rancher.container.create_agent: "true"
+      io.rancher.container.agent.role: "environment"
       {{- if eq .Values.RUN_ONCE "true" }}
       io.rancher.container.start_once: "true"
       {{- end }}

--- a/templates/letsencrypt/4/rancher-compose.yml
+++ b/templates/letsencrypt/4/rancher-compose.yml
@@ -113,17 +113,30 @@
       required: true
       type: enum
       options:
+        - Aurora
+        - Azure
         - CloudFlare
         - DigitalOcean
         - DNSimple
         - Dyn
         - Gandi
+        - NS1
         - Ovh
         - Route53
         - Vultr
         - HTTP
-        - Azure
-        - NS1
+    - variable: AURORA_USER_ID
+      label: Aurora User ID
+      type: string
+      required: false
+    - variable: AURORA_KEY
+      label: Aurora Key
+      type: string
+      required: false
+    - variable: AURORA_ENDPOINT
+      label: Aurora Endpoint URL (Optional)
+      type: string
+      required: false
     - variable: AWS_ACCESS_KEY
       label: AWS Route53 Access Key Id
       description: Enter the Access Key Id for your AWS account.
@@ -203,6 +216,10 @@
       label: Gandi API Key
       description: Enter the API key for your Gandi account.
       type: password
+      required: false
+    - variable: NS1_API_KEY
+      label: NS1 API Key
+      type: string
       required: false
     - variable: OVH_APPLICATION_KEY
       label: OVH Application Key


### PR DESCRIPTION
PR #577 was supposed to contain environment variables for Aurora DNS and NS1, and the `DNS_RESOLVERS` variable (#585), as you can tell from the README.md and #507. Unfortunately though, they were not included and this PR fixes that.