### PR TITLE
drone typo fix for drone_admin

### DIFF
--- a/templates/drone/2/docker-compose.yml.tpl
+++ b/templates/drone/2/docker-compose.yml.tpl
@@ -21,7 +21,7 @@ services:
       DRONE_SECRET: ${drone_secret}
       DRONE_OPEN: ${drone_open}
 {{- if (.Values.drone_admin)}}
-      DRONE_ADMIN: ${drone_admins}
+      DRONE_ADMIN: ${drone_admin}
 {{- end}}
 {{- if (.Values.drone_orgs)}}
       DRONE_ORGS: ${drone_orgs}

--- a/templates/drone/3/docker-compose.yml.tpl
+++ b/templates/drone/3/docker-compose.yml.tpl
@@ -21,7 +21,7 @@ services:
       DRONE_SECRET: ${drone_secret}
       DRONE_OPEN: ${drone_open}
 {{- if (.Values.drone_admin)}}
-      DRONE_ADMIN: ${drone_admins}
+      DRONE_ADMIN: ${drone_admin}
 {{- end}}
 {{- if (.Values.drone_orgs)}}
       DRONE_ORGS: ${drone_orgs}

--- a/templates/drone/4/docker-compose.yml.tpl
+++ b/templates/drone/4/docker-compose.yml.tpl
@@ -37,7 +37,7 @@ services:
       DRONE_SECRET: ${drone_secret}
       DRONE_OPEN: ${drone_open}
 {{- if (.Values.drone_admin)}}
-      DRONE_ADMIN: ${drone_admins}
+      DRONE_ADMIN: ${drone_admin}
 {{- end}}
 {{- if (.Values.drone_orgs)}}
       DRONE_ORGS: ${drone_orgs}


### PR DESCRIPTION
Change the `drone_admins` variable to `drone_admin`. Without this change, the drone admin will be empty even if you typed one during creating the stack.