### PR TITLE
Fix registry stack volume naming convention to avoid forward slashes …

### DIFF
--- a/templates/registry/0/docker-compose.yml
+++ b/templates/registry/0/docker-compose.yml
@@ -8,7 +8,7 @@ db:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/db:/var/lib/mysql
+  - ${DIR}-db:/var/lib/mysql
 sslproxy:
   image: nginx:1.9.9
   tty: true
@@ -16,8 +16,8 @@ sslproxy:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/etc/nginx/certs:ro
-  - ${DIR}/proxy:/etc/nginx/conf.d:ro
+  - ${DIR}-certs:/etc/nginx/certs:ro
+  - ${DIR}-proxy:/etc/nginx/conf.d:ro
 registry:
   image: registry:2.1
   environment:
@@ -42,8 +42,8 @@ registry:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/certs:ro
-  - ${DIR}/data:/var/lib/registry
+  - ${DIR}-certs:/certs:ro
+  - ${DIR}-data:/var/lib/registry
 lb:
   image: rancher/load-balancer-service
   tty: true
@@ -92,8 +92,8 @@ portus:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/proxy:/etc/nginx/conf.d
+  - ${DIR}-certs:/certs
+  - ${DIR}-proxy:/etc/nginx/conf.d
   links:
   - db:db
   labels:

--- a/templates/registry/1/docker-compose.yml
+++ b/templates/registry/1/docker-compose.yml
@@ -8,7 +8,7 @@ db:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/db:/var/lib/mysql
+  - ${DIR}-db:/var/lib/mysql
 sslproxy:
   image: nginx:1.9.9
   tty: true
@@ -16,8 +16,8 @@ sslproxy:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/etc/nginx/certs:ro
-  - ${DIR}/proxy:/etc/nginx/conf.d:ro
+  - ${DIR}-certs:/etc/nginx/certs:ro
+  - ${DIR}-proxy:/etc/nginx/conf.d:ro
 registry:
   image: registry:2.3.1
   environment:
@@ -42,8 +42,8 @@ registry:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/data:/var/lib/registry
+  - ${DIR}-certs:/certs
+  - ${DIR}-data:/var/lib/registry
 lb:
   image: rancher/load-balancer-service
   tty: true
@@ -92,8 +92,8 @@ portus:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/proxy:/etc/nginx/conf.d
+  - ${DIR}-certs:/certs
+  - ${DIR}-proxy:/etc/nginx/conf.d
   links:
   - db:db
   labels:

--- a/templates/registry/2/docker-compose.yml
+++ b/templates/registry/2/docker-compose.yml
@@ -8,7 +8,7 @@ db:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/db:/var/lib/mysql
+  - ${DIR}-db:/var/lib/mysql
   labels:
     registry.portus.db: 1
 sslproxy:
@@ -18,8 +18,8 @@ sslproxy:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/etc/nginx/certs:ro
-  - ${DIR}/proxy:/etc/nginx/conf.d:ro
+  - ${DIR}-certs:/etc/nginx/certs:ro
+  - ${DIR}-proxy:/etc/nginx/conf.d:ro
   labels:
     io.rancher.scheduler.affinity:container_label_soft: registry.portus.db=1
 registry:
@@ -46,8 +46,8 @@ registry:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/data:/var/lib/registry
+  - ${DIR}-certs:/certs
+  - ${DIR}-data:/var/lib/registry
 lb:
   image: rancher/load-balancer-service
   tty: true
@@ -97,8 +97,8 @@ portus:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/proxy:/etc/nginx/conf.d
+  - ${DIR}-certs:/certs
+  - ${DIR}-proxy:/etc/nginx/conf.d
   links:
   - db:db
   labels:

--- a/templates/registry/3/docker-compose.yml
+++ b/templates/registry/3/docker-compose.yml
@@ -8,7 +8,7 @@ db:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/db:/var/lib/mysql
+  - ${DIR}-db:/var/lib/mysql
   labels:
     registry.portus.db: 1
 sslproxy:
@@ -18,8 +18,8 @@ sslproxy:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/etc/nginx/certs:ro
-  - ${DIR}/proxy:/etc/nginx/conf.d:ro
+  - ${DIR}-certs:/etc/nginx/certs:ro
+  - ${DIR}-proxy:/etc/nginx/conf.d:ro
   labels:
     io.rancher.scheduler.affinity:container_label_soft: registry.portus.db=1
 registry:
@@ -46,8 +46,8 @@ registry:
   links:
   - portus:portus
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/data:/var/lib/registry
+  - ${DIR}-certs:/certs
+  - ${DIR}-data:/var/lib/registry
 lb:
   image: rancher/load-balancer-service
   tty: true
@@ -97,8 +97,8 @@ portus:
   tty: true
   stdin_open: true
   volumes:
-  - ${DIR}/certs:/certs
-  - ${DIR}/proxy:/etc/nginx/conf.d
+  - ${DIR}-certs:/certs
+  - ${DIR}-proxy:/etc/nginx/conf.d
   links:
   - db:db
   labels:


### PR DESCRIPTION
…and use dashes to be fully compatible in new docker versions, still backward compatible.
Fixes error
```
(Failed to allocate instance [container:1i107]: Bad instance [container:1i107] in state [error]: Error response from daemon: create MyAppRegistry/db: "MyAppRegistry/db" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path)
```
I am a beginner with rancher so pls review if I have messed anything