### PR TITLE
fix mismatched default backup path

### DIFF
--- a/templates/rancher-backup/0/docker-compose.yml.tpl
+++ b/templates/rancher-backup/0/docker-compose.yml.tpl
@@ -61,7 +61,7 @@ services:
     {{- if (contains .Values.VOLUME_DRIVER "/")}}
       - ${VOLUME_DRIVER}:/data
     {{- else}}
-      - backup-data:/backup
+      - backup-data:/data
     {{- end}}
 
 {{- if not (contains .Values.VOLUME_DRIVER "/")}}


### PR DESCRIPTION
The default mount path is wrong only if using docker volumes