### PR TITLE
Newlines inserted by es-cluster sysctl param breaks yml validation

### DIFF
--- a/templates/es-cluster/0/docker-compose.yml.tpl
+++ b/templates/es-cluster/0/docker-compose.yml.tpl
@@ -4,10 +4,7 @@ services:
         labels: 
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
         environment: 
             - "cluster.name=${cluster_name}"
@@ -38,9 +35,7 @@ services:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
             io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            {{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
         environment: 
             - "cluster.name=${cluster_name}"
@@ -71,10 +66,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.0
         environment: 
             - "cluster.name=${cluster_name}"

--- a/templates/es-cluster/1/docker-compose.yml.tpl
+++ b/templates/es-cluster/1/docker-compose.yml.tpl
@@ -4,10 +4,7 @@ services:
         labels: 
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment: 
             - "cluster.name=${cluster_name}"
@@ -37,10 +34,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment: 
             - "cluster.name=${cluster_name}"
@@ -71,10 +65,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment: 
             - "cluster.name=${cluster_name}"

--- a/templates/es-cluster/2/docker-compose.yml.tpl
+++ b/templates/es-cluster/2/docker-compose.yml.tpl
@@ -4,10 +4,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment:
             - "cluster.name=${cluster_name}"
@@ -37,10 +34,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment:
             - "cluster.name=${cluster_name}"
@@ -71,10 +65,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.4.2
         environment:
             - "cluster.name=${cluster_name}"

--- a/templates/es-cluster/3/docker-compose.yml.tpl
+++ b/templates/es-cluster/3/docker-compose.yml.tpl
@@ -4,10 +4,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
         environment:
             - "cluster.name=${cluster_name}"
@@ -37,10 +34,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
         environment:
             - "cluster.name=${cluster_name}"
@@ -71,10 +65,7 @@ services:
         labels:
             io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
             io.rancher.container.hostname_override: container_name
-            io.rancher.sidekicks: es-storage
-            {{- if eq .Values.UPDATE_SYSCTL "true" -}}
-                ,es-sysctl
-            {{- end}}
+            io.rancher.sidekicks: es-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
         image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
         environment:
             - "cluster.name=${cluster_name}"


### PR DESCRIPTION
Tested the current implementation on v1.5.10 and v1.6.10 but both error out when launched from the UI.