### PR TITLE
upgrde rancher dns to 0.7.6 on gandi stack due to a breaking change on gandi's api

### DIFF
--- a/infra-templates/gandi-dns/1/docker-compose.yml
+++ b/infra-templates/gandi-dns/1/docker-compose.yml
@@ -1,0 +1,13 @@
+gandidns:
+  image: rancher/external-dns:v0.7.6
+  command: -provider=gandi
+  expose:
+   - 1000
+  environment:
+    GANDI_APIKEY: ${GANDI_APIKEY}
+    ROOT_DOMAIN: ${ROOT_DOMAIN}
+    NAME_TEMPLATE: ${NAME_TEMPLATE}
+    TTL: ${TTL}
+  labels:
+    io.rancher.container.create_agent: "true"
+    io.rancher.container.agent.role: "external-dns"

--- a/infra-templates/gandi-dns/1/rancher-compose.yml
+++ b/infra-templates/gandi-dns/1/rancher-compose.yml
@@ -1,0 +1,43 @@
+# notemplating
+.catalog:
+  name: "Gandi DNS"
+  version: "v0.1.1"
+  description: "Rancher External DNS service powered by Gandi. Requires Rancher version v1.1.0"
+  maintainer: "Frederic Leger <contact@webofmars.com>"
+  minimum_rancher_version: v1.6.0-rc1
+  #maximum_rancher_version:
+  questions:
+    - variable: "GANDI_APIKEY"
+      label: "Gandi API key"
+      description: "API key for your Gandi account"
+      type: "string"
+      required: true
+    - variable: "ROOT_DOMAIN"
+      label: "Root Domain"
+      description: "The domain name managed by Gandi."
+      type: "string"
+      required: true
+    - variable: "TTL"
+      label: "TTL"
+      description: "The resource record cache time to live (TTL), in seconds (minimum 300)"
+      type: "int"
+      default: 300
+      required: false
+    - variable: "NAME_TEMPLATE"
+      label: "DNS Name Template"
+      description: |
+        Name template used to construct the subdomain part (left of the root domain name) of the DNS record names.
+        Supported placeholders: %{{service_name}}, %{{stack_name}}, %{{environment_name}}.
+        By default DNS entries will be named '<service>.<stack>.<environment>.<domain>'.
+      type: "string"
+      default: "%{{service_name}}.%{{stack_name}}.%{{environment_name}}"
+      required: false
+
+gandidns:
+  health_check:
+    port: 1000
+    interval: 15000
+    unhealthy_threshold: 2
+    request_line: GET / HTTP/1.0
+    healthy_threshold: 2
+    response_timeout: 2000

--- a/infra-templates/gandi-dns/config.yml
+++ b/infra-templates/gandi-dns/config.yml
@@ -1,7 +1,7 @@
 name: GANDI DNS
 description: |
   Rancher External DNS service powered by Gandi.net
-version: v0.1.0
+version: v0.1.1
 category: External DNS
 labels:
   io.rancher.orchestration.supported: 'cattle,mesos,swarm,kubernetes'


### PR DESCRIPTION
see https://github.com/rancher/rancher/issues/10136