### PR TITLE
Updated traefik package to v1.4.0

### DIFF
--- a/templates/traefik/11/README.md
+++ b/templates/traefik/11/README.md
@@ -1,0 +1,80 @@
+# Traefik active load balancer
+
+### Info:
+
+ This template deploys traefik active load balancers on top of Rancher. The configuration is generated and updated with confd from Rancher metadata.
+ It would be deployed in hosts with label traefik_lb=true.
+
+### Config:
+
+- rancher_integration = "metadata" # Rancher integration method.
+- host_label = "traefik_lb=true" # Host label where to run traefik service.
+- http_port = 8080  # Port exposed to get access to the published services.
+- https_port = 8443  # Port exposed to get secured access to the published services.
+- admin_port = 8000  # Port exposed to get admin access to the traefik service.
+- https_enable = <false | true | only>
+  - false: Enable http enpoints and disable https ones.
+  - true: Enable http and https endpoints.
+  - only: Enable https endpoints and redirect http to https.
+- acme_enable = false               # Enable/Disable acme traefik support.
+- acme_email = "test@traefik.io"    # acme user email
+- acme_ondemand = true              # acme ondemand parameter.
+- acme_onhostrule = true            # acme onHostRule parameter.
+- acme_caserver = "https://acme-v01.api.letsencrypt.org/directory"          # acme caServer parameter.
+- acme_vol_name = "traefik_acme_vol"    # Volume name to user by acme sidekick
+- acme_vol_driver = "local"   # Volume driver to user by acme sidekick
+- ssl_key # Paste your ssl key. *Required if you enable https
+- ssl_crt # Paste your ssl crt. *Required if you enable https
+- insecure_skip = false # Enable InsecureSkipVerify param.
+- compress_enable = true    # Enable traefik compression
+- refresh_interval = 10s  # Interval to refresh traefik rules.toml from rancher-metadata.
+- admin_readonly = false # Set REST API to read-only mode.
+- admin_statistics = 10 # Enable more detailed statistics, extend recent errors number.
+- admin_auth_method = "basic" # Selec auth method, basic or digest.
+- admin_users = "" # Paste basic or digest users created with htdigest, one user per line.
+- prometheus_enable = false # Enable prometheus statistics
+- prometheus_buckets = "[0.1,0.3,1.2,5.0]" # Prometheus buckets
+- cattle_url = ""           # Cattle url if you choose api integration
+- cattle_access_key = ""    # Cattle access key if you choose api integration
+- cattle_secret_key = ""    # Cattle secret key if you choose api integration    
+### Service configuration labels:
+
+Traefik labels has to be added to your services, in order to get included in traefik config.
+
+## Metadata or api
+
+Please use traefik defined labels if you choose metadata or api rancher integration. 
+
+[Traefik rancher backend labels][traefik rancher backend]
+
+Metadata is the prefered and recommended rancher integration.
+
+Api integration needs you create an environment API key in your rancher environment. Also, it needs you provide CATTLE_URL, CATTLE_ACCESS_KEY and CATTLE_SECRET_KEY.
+
+## External
+
+Use this labels if you choose extenal rancher integration.
+
+- traefik.enable = <true | false>
+  - true: the service will be published as *service_name.stack_name.traefik_domain*
+  - stack: the service will be published as *stack_name.traefik_domain*. WARNING: You could have collisions inside services within your stack
+  - false: the service will not be published
+- traefik.alias = < alias >         # Alternate names to route rule. Multiple values separated by ",". WARNING: You could have collisions BE CAREFULL
+- traefik.domain = < domain >       # Domain names to route rule. Multiple values separated by ","
+- traefik.path = < path >           # Path to route rule. Multiple paths separated by ","
+- traefik.port = < port >           # Port to expose throught traefik
+- traefik.acme = < true | false >   # Enable/disable ACME traefik feature
+
+### Usage:
+
+ Select Traefik from catalog.
+
+ Set the params.
+
+ Click deploy.
+
+ Access your traefik admin service at $admin_port to see your published services.
+
+Note: To access the services, you need to create A or CNAMES dns entries for every one.
+
+[traefik rancher backend]: https://docs.traefik.io/configuration/backends/rancher/#labels-overriding-default-behaviour

--- a/templates/traefik/11/docker-compose.yml.tpl
+++ b/templates/traefik/11/docker-compose.yml.tpl
@@ -1,0 +1,107 @@
+version: '2'
+services:
+  traefik:
+    ports:
+    - ${admin_port}:8000/tcp
+    - ${http_port}:${http_port}/tcp
+    - ${https_port}:${https_port}/tcp
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+    {{- if or (eq .Values.rancher_integration "external") (eq .Values.acme_enable "true")}}
+      io.rancher.sidekicks: 
+        {{- if eq .Values.rancher_integration "external"}} traefik-conf
+            {{- if eq .Values.acme_enable "true" -}},{{- end -}}
+        {{- end -}}
+        {{- if eq .Values.acme_enable "true" -}}
+            {{- if ne .Values.rancher_integration "external"}} traefik-acme
+            {{- else -}}traefik-acme
+            {{- end -}}
+        {{- end -}}
+    {{- end}}
+      io.rancher.container.hostname_override: container_name
+    image: rawmind/alpine-traefik:1.4.0-3
+    environment:
+    - TRAEFIK_HTTP_PORT=${http_port}
+    - TRAEFIK_HTTP_COMPRESSION=${compress_enable}
+    - TRAEFIK_HTTPS_PORT=${https_port}
+    - TRAEFIK_HTTPS_ENABLE=${https_enable}
+    - TRAEFIK_HTTPS_COMPRESSION=${compress_enable}
+    - TRAEFIK_INSECURE_SKIP=${insecure_skip}
+    - TRAEFIK_ADMIN_ENABLE=true
+    - TRAEFIK_ADMIN_READ_ONLY=${admin_readonly}
+    - TRAEFIK_ADMIN_STATISTICS=${admin_statistics}
+    - TRAEFIK_ADMIN_AUTH_METHOD=${admin_auth_method}
+    - TRAEFIK_ADMIN_AUTH_USERS=${admin_users}
+  {{- if eq .Values.rancher_integration "external"}}
+    - CONF_INTERVAL=${refresh_interval}
+  {{- end}}
+  {{- if eq .Values.acme_enable "true"}}
+    - TRAEFIK_ACME_ENABLE=${acme_enable}
+    - TRAEFIK_ACME_EMAIL=${acme_email}
+    - TRAEFIK_ACME_ONDEMAND=${acme_ondemand}
+    - TRAEFIK_ACME_ONHOSTRULE=${acme_onhostrule}
+    - TRAEFIK_ACME_CASERVER="${acme_caserver}"
+  {{- end}}
+  {{- if ne .Values.rancher_integration "external"}}
+    - TRAEFIK_RANCHER_ENABLE=true
+    - TRAEFIK_RANCHER_MODE=${rancher_integration}
+    {{- if eq .Values.rancher_integration "api"}}
+    - CATTLE_URL=${cattle_url}
+    - CATTLE_ACCESS_KEY=${cattle_access_key}
+    - CATTLE_SECRET_KEY=${cattle_secret_key}
+    {{- end}}
+  {{- end}}
+  {{- if eq .Values.prometheus_enable "true"}}
+    - TRAEFIK_PROMETHEUS_ENABLE=${prometheus_enable}
+    - TRAEFIK_PROMETHEUS_BUCKETS=${prometheus_buckets}
+  {{- end}}
+  {{- if or (eq .Values.rancher_integration "external") (eq .Values.acme_enable "true")}}
+    volumes_from:
+    {{- if eq .Values.rancher_integration "external"}}
+    - traefik-conf
+    {{- end}}
+    {{- if eq .Values.acme_enable "true"}}
+    - traefik-acme
+    {{- end}}
+  {{- end}}
+  {{- if eq .Values.rancher_integration "external"}}
+  traefik-conf:
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+      io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.start_once: 'true'
+    image: rawmind/rancher-traefik:1.3.6
+    network_mode: none
+    volumes:
+      - tools-volume:/opt/tools
+  {{- end}}
+  {{- if eq .Values.acme_enable "true"}}
+  traefik-acme:
+    network_mode: none
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.start_once: true
+    environment:
+      - SERVICE_UID=10001
+      - SERVICE_GID=10001
+      - SERVICE_VOLUME=/opt/traefik/acme
+    volumes:
+      - ${acme_vol_name}:/opt/traefik/acme
+    image: rawmind/alpine-volume:0.0.2-1
+  {{- end}}
+{{- if or (eq .Values.rancher_integration "external") (eq .Values.acme_enable "true")}}
+volumes:
+  {{- if eq .Values.rancher_integration "external"}}
+  tools-volume:
+    driver: local
+    per_container: true
+  {{- end}}
+  {{- if eq .Values.acme_enable "true"}}
+  ${acme_vol_name}:
+    driver: ${acme_vol_driver}
+  {{- end}}
+{{- end}}

--- a/templates/traefik/11/rancher-compose.yml
+++ b/templates/traefik/11/rancher-compose.yml
@@ -1,0 +1,208 @@
+version: '2'
+catalog:
+  name: traefik
+  version: v1.4.0-rancher1
+  description: |
+    Traefik load balancer.
+  minimum_rancher_version: v0.59.0
+  maintainer: "Raul Sanchez <rawmind@gmail.com>"
+  uuid: traefik-0
+  questions:
+    - variable: "rancher_integration"
+      label: "Choose rancher integration:"
+      description: |
+        Enable rancher integration mode. Traefik built in integration, metadata or api, or external sidekick integration with confd.
+      default: metadata
+      required: true
+      type: enum
+      options:
+        - metadata
+        - api
+        - external
+    - variable: "host_label"
+      description: "Host label where to run traefik service."
+      label: "Host label:"
+      required: true
+      default: "traefik_lb=true" 
+      type: "string"
+    - variable: "http_port"
+      description: "Traefik http public port to listen."
+      label: "Http port:"
+      required: true
+      default: 8080
+      type: "int"
+    - variable: "https_port"
+      description: "Traefik https public port to listen."
+      label: "Https port:"
+      required: true
+      default: 8443
+      type: "int"
+    - variable: "admin_port"
+      description: "Traefik admin public port to listen."
+      label: "Admin port:"
+      required: true
+      default: 8000 
+      type: "int"
+    - variable: "https_enable"
+      label: "Https enable:"
+      description: |
+        Enable https working mode. If you activate, you need to fill SSL key and SSL crt in order to work.
+      default: false
+      required: true
+      type: enum
+      options:
+        - false
+        - true
+        - only
+    - variable: "acme_enable"
+      description: "Enable acme support on traefik."
+      label: "ACME enable:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "acme_email"
+      description: "ACME user email."
+      label: "ACME email:"
+      required: true
+      default: "test@traefik.io" 
+      type: "string"
+    - variable: "acme_ondemand"
+      description: "Enable acme ondemand."
+      label: "ACME ondemand:"
+      required: true
+      default: true 
+      type: "boolean"
+    - variable: "acme_onhostrule"
+      description: "Enable acme onHostRule."
+      label: "ACME onHostRule:"
+      required: true
+      default: true 
+      type: "boolean"
+    - variable: "acme_caserver"
+      description: "ACME caServer to use."
+      label: "ACME caServer:"
+      required: true
+      default: "https://acme-v01.api.letsencrypt.org/directory"
+      type: "string"
+    - variable: "acme_vol_name"
+      description: "The volume name shared to store ACME certs"
+      label: "ACME Volume Name"
+      required: true
+      default: "traefik_acme_vol"
+      type: "string"
+    - variable: "acme_vol_driver"
+      description: "The volume driver shared to store ACME certs"
+      label: "ACME Volume Driver"
+      required: true
+      default: "local"
+      type: enum
+      options: # List of options if using type of `enum`
+        - local
+        - rancher-nfs
+        - rancher-efs
+        - rancher-ebs
+    - variable: "ssl_key"
+      description: "SSL key to secure the service. *Required if you enable https"
+      label: "Https key"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "ssl_crt"
+      description: "SSL cert to secure the service. *Required if you enable https"
+      label: "Https crt"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "insecure_skip"
+      description: "Enable InsecureSkipVerify param."
+      label: "InsecureSkipVerify:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "compress_enable"
+      label: "Enable compression:"
+      description: |
+        Enable Traefik compression for entrypoints.
+      default: true
+      required: true
+      type: "boolean"
+    - variable: "refresh_interval"
+      description: "Interval to poll/apply configuration changes." 
+      label: "Refresh Interval (s):"
+      required: true
+      default: 10 
+      type: "int"
+    - variable: "admin_readonly"
+      label: "Admin readonly:"
+      description: |
+        Set admin to readonly mode.
+      default: false
+      required: true
+      type: "boolean"
+    - variable: "admin_statistics"
+      description: "Enable more detailed statistics."
+      label: "Admin statistics history:"
+      required: true
+      default: 10
+      type: "int"
+    - variable: "admin_auth_method"
+      description: "Admin auth method on the webui."
+      label: "Admin auth method:"
+      required: true
+      default: "basic"
+      type: enum
+      options: # List of options if using type of `enum`
+        - basic
+        - digest
+    - variable: "admin_users"
+      description: "Admin auth user list on the webui. Generate with htpassword for basic or htdigest with traefik realm for digest."
+      label: "Admin users:"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "prometheus_enable"
+      description: "To enable statistics to be pulled by Prometheus."
+      label: "Prometheus enable"
+      default: false
+      required: true
+      type: "boolean"
+    - variable: "prometheus_buckets"
+      description: "To define your own buckets"
+      label: "Prometheus buckets"
+      default: "[0.1,0.3,1.2,5.0]"
+      required: true
+      type: "string"
+    - variable: "cattle_url"
+      description: "API cattle url"
+      label: "Cattle URL"
+      default: ""
+      required: false
+      type: "string"
+    - variable: "cattle_access_key"
+      description: "API environment access key"
+      label: "Cattle access key"
+      default: ""
+      required: false
+      type: "string"
+    - variable: "cattle_secret_key"
+      description: "API environment secret key"
+      label: "Cattle secret key"
+      default: ""
+      required: false
+      type: "string"
+services:
+  traefik:
+    retain_ip: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 5000
+      port: 8000
+      unhealthy_threshold: 3
+      interval: 5000
+      strategy: recreate
+    metadata:
+      traefik:
+        ssl_key: |
+          ${ssl_key}
+        ssl_crt: |
+          ${ssl_crt}

--- a/templates/traefik/config.yml
+++ b/templates/traefik/config.yml
@@ -1,7 +1,7 @@
 name: Traefik
 description: |
-  (Experimental) Traefik active load balancer
-version: v1.3.6-rancher1
+  Traefik active load balancer
+version: v1.4.0-rancher1
 category: Load Balancing
 maintainer: "Raul Sanchez <rawmind@gmail.com>"
 minimum_rancher_version: v0.59.0


### PR DESCRIPTION
- Refactored traefik package.
- Updated traefik to v1.4.0
- Added support for traefik built in rancher integration.
- Added support for traefik prometheus buckets.
- 3 distinct mehtods to integrate wit rancher:
  - Metadata: Built in by traefik
  - Api: Built in by traefik
  - External: Built with a sidekick and confd. 