### PR TITLE
Netdata template cosmetic fixes

### DIFF
--- a/templates/netdata/1/docker-compose.yml
+++ b/templates/netdata/1/docker-compose.yml
@@ -1,0 +1,13 @@
+netdata:
+  image: titpetric/netdata:latest
+  labels:
+    io.rancher.scheduler.global: 'true'
+  uts: host
+  cap_add:
+  - SYS_PTRACE
+  volumes:
+  - /proc:/host/proc:ro
+  - /sys:/host/sys:ro
+  - /var/run/docker.sock:/var/run/docker.sock:ro
+  environment:
+    NETDATA_PORT: "${NETDATA_PORT}"

--- a/templates/netdata/1/rancher-compose.yml
+++ b/templates/netdata/1/rancher-compose.yml
@@ -1,0 +1,13 @@
+.catalog:
+  name: netdata
+  version: v1.8.0
+  description: Real-time performance monitoring, done right!
+  questions:
+    - variable: NETDATA_PORT
+      label: Port
+      description: Container port to access netdata
+      required: true
+      type: int
+      default: 19999
+netdata:
+  scale: 1


### PR DESCRIPTION
- If you don't mount docker socket from host netdata will not be able to understand human-readable names for cgroups, so all you containers will be ``aa123bc``.
- Also use host UTS namespace to set hostname of a container to an agent hostname. In the case of one container per host it will be easy to indentify netdata instances