### PR TITLE
Update drone to 0.8.3

### DIFF
--- a/templates/drone/7/README.md
+++ b/templates/drone/7/README.md
@@ -1,0 +1,19 @@
+# Drone
+
+### Info:
+
+This template creates an instance of Drone CI server 0.8.3 along with selectable number of agents to perform the builds.
+
+### Usage:
+
+Select the Drone template from the catalog. Provide the following information:
+
+1. Publish port
+2. Agents scale
+3. Drone secret
+4. Run mode. debug | release
+3. Remote driver and config. (Ie. GitHub)
+4. Database driver and config. (Ie. sqlite)
+
+
+See [Drone documentation](http://readme.drone.io/admin) for complete information.

--- a/templates/drone/7/docker-compose.yml.tpl
+++ b/templates/drone/7/docker-compose.yml.tpl
@@ -1,0 +1,116 @@
+version: '2'
+services:
+  agent:
+    image: drone/agent:${drone_version}
+    environment:
+      DRONE_SERVER: ${drone_server}
+      DRONE_SECRET: ${drone_secret}
+{{- if (.Values.http_proxy)}}
+      HTTP_PROXY: ${http_proxy}
+      http_proxy: ${http_proxy}
+{{- end}}
+{{- if (.Values.https_proxy)}}
+      HTTPS_PROXY: ${https_proxy}
+      https_proxy: ${https_proxy}
+{{- end}}
+{{- if (.Values.no_proxy)}}
+      NO_PROXY: ${no_proxy}
+      no_proxy: ${no_proxy}
+{{- end}}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - server:drone
+    command:
+      - agent
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+  server:
+    image: drone/drone:${drone_version}
+    environment:
+      DRONE_HOST: ${drone_host}
+      GIN_MODE: ${gin_mode}
+{{- if (.Values.drone_debug)}}
+      DRONE_DEBUG: '${drone_debug}'
+{{- end}}
+      DRONE_SECRET: ${drone_secret}
+      DRONE_OPEN: ${drone_open}
+{{- if (.Values.drone_admin)}}
+      DRONE_ADMIN: ${drone_admin}
+{{- end}}
+{{- if (.Values.drone_orgs)}}
+      DRONE_ORGS: ${drone_orgs}
+{{- end}}
+{{- if eq .Values.drone_driver "GitHub"}}
+      DRONE_GITHUB: true
+      DRONE_GITHUB_CLIENT: ${drone_driver_client}
+      DRONE_GITHUB_SECRET: ${drone_driver_secret}
+{{- end}}
+{{- if eq .Values.drone_driver "Bitbucket Cloud"}}
+      DRONE_BITBUCKET: true
+      DRONE_BITBUCKET_CLIENT: ${drone_driver_client}
+      DRONE_BITBUCKET_SECRET: ${drone_driver_secret}
+{{- end}}
+{{- if eq .Values.drone_driver "Bitbucket Server"}}
+      DRONE_STASH: true
+      DRONE_STASH_GIT_USERNAME: ${drone_driver_user}
+      DRONE_STASH_GIT_PASSWORD: ${drone_driver_password}
+      DRONE_STASH_CONSUMER_KEY: ${drone_driver_client}
+      DRONE_STASH_CONSUMER_RSA_STRING: ${drone_driver_secret}
+      DRONE_STASH_URL: ${drone_driver_url}
+{{- end}}
+{{- if eq .Values.drone_driver "GitLab"}}
+      DRONE_GITLAB: true
+      DRONE_GITLAB_CLIENT: ${drone_driver_secret}
+      DRONE_GITLAB_SECRET: ${drone_driver_secret}
+      DRONE_GITLAB_URL: ${drone_driver_url}
+{{- end}}
+{{- if eq .Values.drone_driver "Gogs"}}
+      DRONE_GOGS: true
+      DRONE_GOGS_URL: ${drone_driver_url}
+{{- end}}
+{{- if ne .Values.database_driver "sqlite"}}
+      DRONE_DATABASE_DRIVER: ${database_driver}
+      DRONE_DATABASE_DATASOURCE: ${database_source}
+{{- end}}
+{{- if (.Values.http_proxy)}}
+      HTTP_PROXY: ${http_proxy}
+      http_proxy: ${http_proxy}
+{{- end}}
+{{- if (.Values.https_proxy)}}
+      HTTPS_PROXY: ${https_proxy}
+      https_proxy: ${https_proxy}
+{{- end}}
+{{- if (.Values.no_proxy)}}
+      NO_PROXY: ${no_proxy}
+      no_proxy: ${no_proxy}
+{{- end}}
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+{{- if eq .Values.database_driver "sqlite"}}
+      io.rancher.sidekicks: server-volume
+    volumes_from:
+      - server-volume
+  server-volume:
+    image: rawmind/alpine-volume:0.0.2-2
+    environment:
+      SERVICE_GID: '0'
+      SERVICE_UID: '0'
+      SERVICE_VOLUME: /var/lib/drone
+    network_mode: none
+    volumes:
+      - /var/lib/drone
+    labels:
+      io.rancher.container.start_once: 'true'
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+{{- end}}
+  lb:
+    image: rancher/lb-service-haproxy:v0.7.17
+    ports:
+      - ${host_port}:${host_port}
+    labels:
+      io.rancher.scheduler.global: 'true'
+      io.rancher.scheduler.affinity:host_label_soft: ${drone_lb_host_label}

--- a/templates/drone/7/rancher-compose.yml
+++ b/templates/drone/7/rancher-compose.yml
@@ -1,0 +1,190 @@
+version: 2
+catalog:
+  name: Drone
+  version: 0.8.3-rancher1
+  upgrade_from: 0.8.2-rancher1
+  description: |
+    Drone CI Server ref http://readme.drone.io/admin/installation-guide/
+  questions:
+    - variable: drone_host
+      label: Drone Host URL
+      description: Intended URL Drone will be hosted on, e.g. http://drone.mycompany.com.
+      required: true
+      type: string
+    - variable: host_port
+      label: Drone Server Host Port
+      description: Public port that will be exposed on service creation.
+      required: true
+      default: 8000
+      type: int
+    - variable: agent_scale
+      label: Drone Agent Scale
+      description: Drone agent scale to deploy
+      required: true
+      default: 1
+      type: int
+    - variable: drone_secret
+      label: Server and Agents Secret
+      description: Server and agents secret to be communicate. http://readme.drone.io/admin/user-registration/
+      type: password
+      required: true
+    - variable: gin_mode
+      label: Run mode
+      description: "Drone run mode, GIN_MODE"
+      type: enum
+      default: "release"
+      options:
+        - "release"
+        - "debug"
+      required: true
+    - variable: drone_open
+      label: Open Registration
+      description: |
+        Users self register. http://readme.drone.io/admin/user-registration/
+      required: true
+      default: true
+      type: enum
+      options:
+        - true
+        - false
+    - variable: drone_admin
+      label: Drone Admin
+      description: List of admins for drone comma seperated. http://readme.drone.io/admin/user-admins/
+      type: string
+      required: false
+    - variable: drone_orgs
+      label: Organizations
+      description: Comman seperated list of org that can access drone. http://readme.drone.io/admin/user-registration/
+      type: string
+      required: false
+    - variable: "drone_driver"
+      type: "enum"
+      required: true
+      label: "Remote Driver"
+      default: "GitHub"
+      description: "Remote Git and Auth scheme. ref http://readme.drone.io/admin"
+      options:
+        - GitHub
+        - GitLab
+        - Gogs
+        - Bitbucket Cloud
+        - Bitbucket Server
+    - variable: drone_driver_client
+      label: Remote Driver Client
+      description: "Client key from remote driver. Required for GitHub, Bitbucket Cloud, Bitbucket Server and GitLab."
+      type: string
+      required: false
+    - variable: drone_driver_secret
+      label: Remote Driver Secret
+      description: "Secret key from remote driver. Required for GitHub, Bitbucket Cloud, Bitbucket Server and GitLab."
+      type: multiline
+      required: false
+    - variable: drone_driver_url
+      label: Remote Driver URL
+      description: "Remote Driver server url. Required for GitLab, Gogs and Bitbucket Server; see http://readme.drone.io/admin."
+      type: string
+      required: false
+    - variable: drone_driver_user
+      label: Remote Driver Username
+      description: "Remote Driver username. Required for BitBucket Server; see http://docs.drone.io/install-for-bitbucket-server/."
+      type: string
+      required: false
+    - variable: drone_driver_password
+      label: Remote Driver Password
+      description: "Remote Driver password. Required for BitBucket Server, http://docs.drone.io/install-for-bitbucket-server/."
+      type: password
+      required: false
+    - variable: drone_server
+      label: Drone Server
+      description: "Drone sever identifier. Used by the agent to connect to the server (does not require change)."
+      type: string
+      default: "drone:9000"
+    - variable: drone_version
+      label: Drone Version
+      description: "Drone version/Docker tag used for the Drone container images."
+      type: enum
+      default: "0.8.3"
+      options:
+        - 0.8.3
+        - 0.8.2
+        - 0.8.1
+        - 0.8.0
+        - '0.8'
+        - latest
+    - variable: database_driver
+      label: Database Driver
+      description: "Database driver. If sqlite, additional volume would be mounted at /var/lib/drone."
+      type: enum
+      default: "sqlite"
+      options:
+        - "sqlite"
+        - "mysql"
+        - "postgres"
+      required: true
+    - variable: "database_source"
+      type: "string"
+      label: "Database source"
+      description: "Database datasource. Required if database driver is mysql or postgres, http://readme.drone.io/admin/database-engines/"
+      required: false
+    - variable: "http_proxy"
+      type: string
+      label: HTTP Proxy
+      description: "Optional: HTTP forward proxy URL."
+      required: false
+    - variable: "https_proxy"
+      type: string
+      label: HTTPS Proxy
+      description: "Optional: HTTPS forward proxy URL."
+      required: false
+    - variable: "no_proxy"
+      type: string
+      label: No Proxy
+      description: "Optional: No proxy hosts (comma-separated hostnames/IPs)."
+      required: false
+      default: "drone"
+    - variable: "drone_debug"
+      label: Drone Debug
+      description: "Enable debug output with the Drone server."
+      type: enum
+      options:
+        - 'true'
+        - 'false'
+      default: 'false'
+    - variable: drone_lb_host_label
+      label: Drone LB Host Label
+      description: Host label (soft affinity) for scheduling of the load balancer service.
+      required: true
+      default: "drone_lb=true"
+      type: string
+services:
+  agent:
+    scale: ${agent_scale}
+    start_on_create: true
+  server:
+    scale: 1
+    start_on_create: true
+    health_check:
+      port: 8000
+      interval: 2000
+      unhealthy_threshold: 3
+      strategy: recreate
+      request_line: GET / HTTP/1.0
+      healthy_threshold: 2
+      response_timeout: 2000
+  lb:
+    start_on_create: true
+    lb_config:
+      certs: []
+      port_rules:
+      - priority: 1
+        protocol: http
+        service: server
+        source_port: ${host_port}
+        target_port: 8000
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 2000
+      port: 42
+      unhealthy_threshold: 3
+      interval: 2000
+      strategy: recreate

--- a/templates/drone/7/rancher-compose.yml
+++ b/templates/drone/7/rancher-compose.yml
@@ -4,7 +4,7 @@ catalog:
   version: 0.8.3-rancher1
   upgrade_from: 0.8.2-rancher1
   description: |
-    Drone CI Server ref http://readme.drone.io/admin/installation-guide/
+    Drone CI Server ref http://docs.drone.io/installation/
   questions:
     - variable: drone_host
       label: Drone Host URL
@@ -25,7 +25,7 @@ catalog:
       type: int
     - variable: drone_secret
       label: Server and Agents Secret
-      description: Server and agents secret to be communicate. http://readme.drone.io/admin/user-registration/
+      description: Server and agents secret to be communicate. http://docs.drone.io/user-registration/
       type: password
       required: true
     - variable: gin_mode
@@ -40,7 +40,7 @@ catalog:
     - variable: drone_open
       label: Open Registration
       description: |
-        Users self register. http://readme.drone.io/admin/user-registration/
+        Users self register. http://docs.drone.io/user-registration/
       required: true
       default: true
       type: enum
@@ -49,12 +49,12 @@ catalog:
         - false
     - variable: drone_admin
       label: Drone Admin
-      description: List of admins for drone comma seperated. http://readme.drone.io/admin/user-admins/
+      description: List of admins for drone comma seperated. http://docs.drone.io/user-admins/
       type: string
       required: false
     - variable: drone_orgs
       label: Organizations
-      description: Comman seperated list of org that can access drone. http://readme.drone.io/admin/user-registration/
+      description: Comman seperated list of org that can access drone. http://docs.drone.io/user-registration/
       type: string
       required: false
     - variable: "drone_driver"
@@ -62,7 +62,7 @@ catalog:
       required: true
       label: "Remote Driver"
       default: "GitHub"
-      description: "Remote Git and Auth scheme. ref http://readme.drone.io/admin"
+      description: "Remote Git and Auth scheme. ref http://docs.drone.io/installation/"
       options:
         - GitHub
         - GitLab
@@ -81,7 +81,7 @@ catalog:
       required: false
     - variable: drone_driver_url
       label: Remote Driver URL
-      description: "Remote Driver server url. Required for GitLab, Gogs and Bitbucket Server; see http://readme.drone.io/admin."
+      description: "Remote Driver server url. Required for GitLab, Gogs and Bitbucket Server; see http://docs.drone.io/installation/."
       type: string
       required: false
     - variable: drone_driver_user
@@ -124,7 +124,7 @@ catalog:
     - variable: "database_source"
       type: "string"
       label: "Database source"
-      description: "Database datasource. Required if database driver is mysql or postgres, http://readme.drone.io/admin/database-engines/"
+      description: "Database datasource. Required if database driver is mysql or postgres, http://docs.drone.io/database-settings/"
       required: false
     - variable: "http_proxy"
       type: string

--- a/templates/drone/config.yml
+++ b/templates/drone/config.yml
@@ -1,5 +1,5 @@
 name: Drone
 description: |
     Drone CI Server
-version: 0.8.2-rancher1
+version: 0.8.3-rancher1
 category: Continuous Integration


### PR DESCRIPTION
- Update Drone to version 0.8.3
- Update rancher/lb-service-haproxy to 0.7.17
- Update rawmind/alpine-volume to 0.0.2-2
- Update Drone CI documentation endpoints to the new `http://docs.drone.io` URL
  
Temporarily closed.