### PR TITLE
Added external flag for environment scoped volumes

### DIFF
--- a/templates/letsencrypt/4/docker-compose.yml.tpl
+++ b/templates/letsencrypt/4/docker-compose.yml.tpl
@@ -59,7 +59,7 @@ volumes:
       {{.Values.STORAGE_DRIVER_OPT}}
     {{- end }}
     {{- end }}
-    {{- if .Values.ENVIRONMENT_SCOPED}}
+    {{- if eq .Values.ENVIRONMENT_SCOPED "true" }}
     external: true
     {{- end }}
 {{- end }}

--- a/templates/letsencrypt/4/docker-compose.yml.tpl
+++ b/templates/letsencrypt/4/docker-compose.yml.tpl
@@ -59,4 +59,7 @@ volumes:
       {{.Values.STORAGE_DRIVER_OPT}}
     {{- end }}
     {{- end }}
+    {{- if .Values.ENVIRONMENT_SCOPED}}
+    external: true
+    {{- end }}
 {{- end }}

--- a/templates/letsencrypt/4/docker-compose.yml.tpl
+++ b/templates/letsencrypt/4/docker-compose.yml.tpl
@@ -52,6 +52,9 @@ services:
 {{- if .Values.VOLUME_NAME}}
 volumes:
   {{.Values.VOLUME_NAME}}:
+    {{- if eq .Values.ENVIRONMENT_SCOPED "true" }}
+    external: true
+    {{- else}}
     {{- if .Values.STORAGE_DRIVER}}
     driver: {{.Values.STORAGE_DRIVER}}
     {{- if .Values.STORAGE_DRIVER_OPT}}
@@ -59,7 +62,5 @@ volumes:
       {{.Values.STORAGE_DRIVER_OPT}}
     {{- end }}
     {{- end }}
-    {{- if eq .Values.ENVIRONMENT_SCOPED "true" }}
-    external: true
     {{- end }}
 {{- end }}

--- a/templates/letsencrypt/4/rancher-compose.yml
+++ b/templates/letsencrypt/4/rancher-compose.yml
@@ -107,6 +107,13 @@
         E.g. for the `rancher-ebs` driver you should specify the required 'size' option like this: "size: 1".
       required: false
       type: string
+    - variable: ENVIRONMENT_SCOPED
+      label: Environment scoped storage volume
+      description: |
+        If the storage volume is existing and environment scoped, this must be set.
+      required: true
+      type: boolean
+      default: false
     - variable: PROVIDER
       label: Domain Validation Method
       description: Select a DNS provider to use for domain validation. Use 'HTTP' if your domain is hosted elsewhere.


### PR DESCRIPTION
To use an environment scoped volume the option `external: true` is required in the volumes section. If the option is missing, the volume is always stack scoped. The additional flag `ENVIRONMENT_SCOPED` fix the problem.