### PR TITLE
Update minio to 2018-01-02_1

### DIFF
--- a/templates/minio/3/README.md
+++ b/templates/minio/3/README.md
@@ -1,0 +1,49 @@
+# Minio.io
+
+### Info:
+
+This template creates, scale in and scale out a multinodes minio cluster on top of Rancher. The configuration is generated with confd from Rancher metadata.
+Cluster size is static after deployement. It's mean that you should redeploy the stack if you should change the size of your cluster (minio.io limitation).
+
+
+### Usage:
+
+Select Minio Cloud Storage from catalog.
+
+Enter the number of nodes for your minio cluster and set the key and secret to connect in minio.
+
+Click deploy.
+
+Minio can now be accessed over the Rancher network on port `9000` (http://IP_CONTAINER:9000). To access from external Rancher network, you need to set load balancer or expose the port 9000.
+ 
+### Disks / nodes
+
+You can set many disks per nodes (max of 4). If you use local disk (no extra Docker driver), you need to mount them on the same `base path` and indicate this name on `Volume Driver / Path` section.
+Moreover, you need to use the same disk name with a number as suffix (from 0 to 4) and report this on `Disk base name` section.
+
+For example, if you should to use 4 disks per nodes:
+- Number of disks per node: 4
+- Volume driver / Path: /data/minio
+- Disk base name: disk
+
+And you have to mount the following partition:
+- /data/minio/disk0
+- /data/minio/disk1
+- /data/minio/disk2
+- /data/minio/disk3
+- 
+
+To more info about nodes and disks, you can read the [official documentation](https://github.com/minio/minio/tree/master/docs/distributed)
+
+
+
+### Advance info
+1. This template create first the container called `rancher-cattle-metadata`. It embedded confd, with some scripts to get many settings from Cattle scheduler and expose them through the volume.
+2. Then, the template create `minio` container. It will launch the scripts provided from `rancher-cattle-metadata` container with `volumes_from`. it will create /opt/scheduler/conf/scheduler.cfg file with some usefull infos about container, service, stack and host. Next,  it will source `/opt/scheduler/conf/scheduler.cfg` and launch confd scripts to configure minio.
+
+### Source, bugs and enhances
+
+ If you found bugs or need enhance, you can open ticket on github:
+ - [Minio official core project](https://github.com/minio/minio)
+ - [Minio docker image](https://github.com/mschneider82/alpine-minio)
+ - [Rancher Cattle metadata docker image](https://github.com/disaster37/rancher-cattle-metadata)

--- a/templates/minio/3/docker-compose.yml.tpl
+++ b/templates/minio/3/docker-compose.yml.tpl
@@ -1,0 +1,71 @@
+version: '2'
+services:
+  minio-server:
+    tty: true
+    image: mschneider82/alpine-minio:2018-01-02_1
+    volumes:
+      - minio-scheduler-setting:/opt/scheduler
+    {{- if eq (printf "%.1s" .Values.VOLUME_DRIVER) "/" }}
+      {{- range $idx, $e := atoi .Values.MINIO_DISKS | until }}
+      - ${VOLUME_DRIVER}/${DISK_BASE_NAME}{{$idx}}:/data/disk{{$idx}}
+      {{- end}}
+    {{- else}}
+       {{- range $idx, $e := atoi .Values.MINIO_DISKS | until }}
+      - minio-data-{{$idx}}:/data/disk{{$idx}}
+      {{- end}}
+    {{- end}}
+    environment:
+      - MINIO_CONFIG_accesskey=${MINIO_ACCESS_KEY}
+      - MINIO_CONFIG_secretkey=${MINIO_SECRET_KEY}
+      - TLS_FQDN=${TLS_FQDN}
+      - CONFD_BACKEND=${CONFD_BACKEND}
+      - CONFD_NODES=${CONFD_NODES}
+      - CONFD_PREFIX_KEY=${CONFD_PREFIX}
+      {{- range $idx, $e := atoi .Values.MINIO_DISKS | until }}
+      - MINIO_DISKS_{{$idx}}=disk{{$idx}}
+      {{- end}}
+    {{- if (ne .Values.DEPLOY_LB "true") and .Values.PUBLISH_PORT}}
+    ports:
+      - ${PUBLISH_PORT}:9000
+    {{- end}}
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+      io.rancher.sidekicks: rancher-cattle-metadata
+  rancher-cattle-metadata:
+    network_mode: none
+    labels:
+      io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+      io.rancher.container.hostname_override: container_name
+      io.rancher.container.start_once: "true"
+    image: webcenter/rancher-cattle-metadata:1.0.1
+    volumes:
+      - minio-scheduler-setting:/opt/scheduler
+  {{- if eq .Values.DEPLOY_LB "true"}}
+  lb:
+    image: rancher/lb-service-haproxy:v0.7.15
+    {{- if .Values.PUBLISH_PORT}}
+    ports:
+      - ${PUBLISH_PORT}:9000/tcp
+    {{- else}}
+    expose:
+      - 9000:9000/tcp
+    {{- end}}
+    links:
+      - minio-server:minio-server
+    labels:
+      io.rancher.container.agent.role: environmentAdmin
+      io.rancher.container.create_agent: 'true'
+  {{- end}}
+
+volumes:
+  minio-scheduler-setting:
+    driver: local
+    per_container: true
+  {{- if ne (printf "%.1s" .Values.VOLUME_DRIVER) "/" }}
+    {{- range $idx, $e := atoi .Values.MINIO_DISKS | until }}
+  minio-data-{{$idx}}:
+    per_container: true
+    driver: ${VOLUME_DRIVER}
+    {{- end}}
+  {{- end}}

--- a/templates/minio/3/rancher-compose.yml
+++ b/templates/minio/3/rancher-compose.yml
@@ -1,0 +1,118 @@
+version: '2'
+catalog:
+  name: Minio
+  version: 2018-01-02_1
+  questions:
+    - variable: "MINIO_SCALE"
+      description: "Number of minio nodes."
+      label: "Minio Nodes"
+      required: true
+      default: 1
+      type: enum
+      options:
+        - 1
+        - 4
+        - 6
+        - 8
+        - 10
+        - 12
+        - 14
+        - 16
+    - variable: "MINIO_DISKS"
+      description: "Number of disks per node"
+      label: "Disks Per Node"
+      required: true
+      type: enum
+      default: 1
+      options:
+        - 1
+        - 2
+        - 4
+    - variable: "DISK_BASE_NAME"
+      description: "The base name for each disk"
+      label: "Disk base name"
+      type: "string"
+      required: true
+      default: "disk"
+    - variable: "VOLUME_DRIVER"
+      description: "Docker driver to store volume or base path for each disks"
+      label: "Volume drver / Path"
+      type: "string"
+      required: true
+      default: "local"
+    - variable: "MINIO_ACCESS_KEY"
+      description: "The key to connect on minio"
+      label: "Minio key"
+      required: true
+      type: "string"
+    - variable: "MINIO_SECRET_KEY"
+      description: "The secret key to connect on minio"
+      label: "Minio secret key"
+      required: true
+      type: "password"
+    - variable: "DEPLOY_LB"
+      description: "Deploy Loadbalancer"
+      label: "Deploy Loadbalancer"
+      required: true
+      type: enum
+      default: "true"
+      options:
+        - "true"
+        - "false"
+    - variable: "PUBLISH_PORT"
+      description: "Set port if you want publish external port for minio or Loadbalancer"
+      label: "Publish port"
+      required: false
+      type: "string"
+      default: "9000"
+    - variable: "TLS_FQDN"
+      description: "Set a FQDN if you want to use https instead of http. A selfsinged cert will be generated."
+      label: "TLS FQDN"
+      required: false
+      type: "string"
+    - variable: "CONFD_BACKEND"
+      description: "The confd backend to grab config"
+      label: "Confd backend"
+      required: true
+      default: "env"
+      type: "string"
+    - variable: "CONFD_NODES"
+      description: "The confd nodes"
+      label: "Confd nodes"
+      required: false
+      type: "string"
+    - variable: "CONFD_PREFIX"
+      description: "The confd prefix"
+      label: "Confd prefix"
+      required: true
+      default: "/minio"
+      type: "string"
+      
+services:
+  minio-server:
+    scale: ${MINIO_SCALE}
+    retain_ip: true
+    health_check:
+      port: 9000
+      interval: 5000
+      unhealthy_threshold: 3
+      request_line: ''
+      healthy_threshold: 2
+      response_timeout: 5000
+  lb:
+    scale: 1
+    start_on_create: true
+    lb_config:
+      certs: []
+      port_rules:
+      - priority: 1
+        protocol: http
+        service: minio-server
+        source_port: 9000
+        target_port: 9000
+    health_check:
+      response_timeout: 2000
+      healthy_threshold: 2
+      port: 42
+      unhealthy_threshold: 3
+      interval: 2000

--- a/templates/minio/config.yml
+++ b/templates/minio/config.yml
@@ -1,7 +1,7 @@
 name: Minio Cloud Storage
 description: |
   Store photos, videos, VMs, containers, log files, or any blob of data as objects.
-version: 2017-11-22_1
+version: 2018-01-02_1
 category: Storage
 maintainer: "Matthias Schneider <ms@wck.biz>"
 license: Apache License


### PR DESCRIPTION
Security fix release

Also supporting TLS_FQDN for optional TLS. By settings this to a Value a selfsinged certificate will be created. This is required to support service side encryption.