### PR TITLE
Updated traefik package to v1.5.0

### DIFF
--- a/templates/traefik/17/README.md
+++ b/templates/traefik/17/README.md
@@ -1,0 +1,104 @@
+# Traefik active load balancer
+
+### Info:
+
+ This template deploys traefik active load balancers on top of Rancher. The configuration is generated and updated with confd from Rancher metadata.
+ It would be deployed in hosts with label traefik_lb=true.
+
+### Config:
+
+- rancher_integration = "metadata" # Rancher integration method.
+- rancher_healthcheck = false   # Enable/Disable traefik rancher services healthcheck filter. Only valid for api and metadata integration.
+- usage_enable = false              # Enable/disable send Traefik [anonymous usage collection](https://docs.traefik.io/basics/#collected-data) 
+- constraints = ""  # Traefik constraints for rancher provider. Only valid for api and metadata integration.
+- host_label = "traefik_lb=true" # Host label where to run traefik service.
+- http_port = 8080  # Port exposed to get access to the published services.
+- https_port = 8443  # Port exposed to get secured access to the published services. 
+- admin_port = 8000  # Port exposed to get admin access to the traefik service.
+- admin_ssl = false  # Enable/Disable ssl on api, rest, ping and webui using  `ssl_key` and `ssl_crt` 
+- https_enable = <false | true | only>
+  - false: Enable http enpoints and disable https ones.
+  - true: Enable http and https endpoints.
+  - only: Enable https endpoints and redirect http to https.
+- https_min_tls = "" # See the [traefik documentation](https://docs.traefik.io/configuration/entrypoints/#specify-minimum-tls-version) for allowed values.
+- acme_enable = false               # Enable/Disable acme traefik support. [acme](https://docs.traefik.io/configuration/acme/)
+- acme_email = "test@traefik.io"    # acme user email
+- acme_challenge = http             # acme challenge parameter. WIP to support dns.
+- acme_onhostrule = true            # acme onHostRule parameter.
+- acme_caserver = "https://acme-v01.api.letsencrypt.org/directory"          # acme caServer parameter.
+- acme_vol_name = "traefik_acme_vol"    # Volume name to user by acme sidekick
+- acme_vol_driver = "local"   # Volume driver to user by acme sidekick
+- ssl_key # Paste your ssl key. *Required if you enable https
+- ssl_crt # Paste your ssl crt. *Required if you enable https
+- insecure_skip = false # Enable InsecureSkipVerify param.
+- compress_enable = true    # Enable traefik compression
+- refresh_interval = 10s  # Interval to refresh traefik rules.toml from rancher-metadata.
+- admin_readonly = false # Set REST API to read-only mode.
+- admin_statistics = 10 # Enable more detailed statistics, extend recent errors number.
+- admin_auth_method = "basic" # Selec auth method, basic or digest.
+- admin_users = "" # Paste basic or digest users created with htdigest, one user per line.
+- metrics_enable="false"        # Enable/disable traefik [metrics](https://docs.traefik.io/configuration/metrics/)  
+- metrics_exporter=""           # Metrics exporter prometheus | datadog | statsd | influxdb 
+- metrics_push="10"             # Metrics exporter push interval (s). datadog | statsd | influxdb
+- metrics_address=""            # Metrics exporter address. datadog | statsd | influxdb 
+- metrics_prometheus_buckets="[0.1,0.3,1.2,5.0]"  # Metrics buckets for prometheus
+    
+### Service configuration labels:
+
+Traefik labels has to be added to your services, in order to get included in traefik config.
+
+## Metadata or api
+
+Please use traefik defined labels if you choose metadata or api rancher integration. 
+
+[Traefik rancher backend labels][traefik rancher backend]
+
+Metadata is the prefered and recommended rancher integration.
+
+## External
+
+Use this labels if you choose extenal rancher integration.
+
+- traefik.enable = < true | stack | false > #Controls if you want to publish or not the service
+  - true: the service will be published as *service_name.stack_name.traefik_domain*
+  - stack: the service will be published as *stack_name.domain*. WARNING: You can have collisions inside services within your stack
+  - false: the service will not be published
+- traefik.priority = <priority>             # Override for frontend priority. Default `5`
+- traefik.protocol = < http | https >       # Override the default protocol `http`
+- traefik.sticky = < true | false   >       # Enable/disable sticky sessions to the backend. Default `false`
+- traefik.backend.loadbalancer.method = < drr | wrr > # Override default lb algorithm `drr`
+- traefik.backend.circuitbreaker.expression = < expression > # Override default backend circuitbreaker expression `NetworkErrorRatio() > 0.5`
+- traefik.frontend.passHostHeader = < true | false > # Forward client Host header to the backend. Default `true`
+- traefik.weight = < weight >               # Override default backend weight `5`
+- traefik.alias = < alias >                 # Alternate names to route rule. Multiple values separated by ",". traefik.domain is appended. WARNING: You could have collisions BE CAREFULL
+- traefik.alias.fqdn = < alias fqdn >                   # Alternate names to route rule. Multiple values separated by ",". traefik.domain must be defined but is not appended here.
+- traefik.domain = < domain.name >          # Domain names to route rules. Multiple domains separated by ","
+- traefik.domain.regexp = < domain.regexp > # Domain name regexp rule. Multiple domains separated by ","
+- traefik.port = <port>                     # port to expose throught traefik. Default `80`
+- traefik.acme = < true | false >           # Enable/disable ACME traefik feature. Default `false`
+- traefik.path = < path >                   # Path rule. Multiple values separated by ","
+- traefik.path.strip = < path >             # Path strip rule. Multiple values separated by ","
+- traefik.path.prefix = < path >            # Path prefix rule. Multiple values separated by ","
+- traefik.path.prefix.strip = < path >      # Path prefix strip rule. Multiple values separated by ","
+- traefik.ratelimit.enable = < true | false >   # Enable/disabe rate-limiting based on client ip. Default `false`
+- traefik.ratelimit.period = < n >          # Replace n with desired amount of seconds in which traefik is checking the limits "average" and "burst". Default `10`
+- traefik.ratelimit.average = < n >         # Change to desired average allowed requests by client ip. Default `100`
+- traefik.ratelimit.burst = < n >           # State what limit the client ip is allowed to burst up to respectively. Default `200`
+
+WARNING: Only services with healthy state are added to traefik, so health checks are mandatory.
+
+More info [rancher-traefik](https://github.com/rawmind0/rancher-traefik)
+
+### Usage:
+
+ Select Traefik from catalog.
+
+ Set the params.
+
+ Click deploy.
+
+ Access your traefik admin service at $admin_port to see your published services.
+
+Note: To access the services, you need to create A or CNAMES dns entries for every one.
+
+[traefik rancher backend]: https://docs.traefik.io/configuration/backends/rancher/#labels-overriding-default-behaviour

--- a/templates/traefik/17/docker-compose.yml.tpl
+++ b/templates/traefik/17/docker-compose.yml.tpl
@@ -4,11 +4,17 @@ services:
     ports:
     - ${admin_port}:8000/tcp
     - ${http_port}:${http_port}/tcp
+  {{- if ne .Values.https_enable "false"}}
     - ${https_port}:${https_port}/tcp
+  {{- end}}
     labels:
       io.rancher.scheduler.global: 'true'
       io.rancher.scheduler.affinity:host_label: ${host_label}
       io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+    {{- if eq .Values.rancher_integration "api"}}
+      io.rancher.container.agent.role: environment
+      io.rancher.container.create_agent: 'true'
+    {{- end}}
     {{- if or (eq .Values.rancher_integration "external") (eq .Values.acme_enable "true")}}
       io.rancher.sidekicks: 
         {{- if eq .Values.rancher_integration "external"}} traefik-conf
@@ -21,13 +27,14 @@ services:
         {{- end -}}
     {{- end}}
       io.rancher.container.hostname_override: container_name
-    image: rawmind/alpine-traefik:1.4.6-0
+    image: rawmind/alpine-traefik:1.5.0-5
     environment:
     - TRAEFIK_HTTP_PORT=${http_port}
     - TRAEFIK_HTTP_COMPRESSION=${compress_enable}
     - TRAEFIK_HTTPS_PORT=${https_port}
     - TRAEFIK_HTTPS_ENABLE=${https_enable}
     - TRAEFIK_HTTPS_COMPRESSION=${compress_enable}
+    - TRAEFIK_USAGE_ENABLE=${usage_enable}
   {{- if ne .Values.https_min_tls ""}}
     - TRAEFIK_HTTPS_MIN_TLS=${https_min_tls}
   {{- end}}
@@ -39,14 +46,15 @@ services:
   {{- end}}
     - TRAEFIK_INSECURE_SKIP=${insecure_skip}
     - TRAEFIK_ADMIN_ENABLE=true
-    - TRAEFIK_ADMIN_READ_ONLY=${admin_readonly}
+    - TRAEFIK_ADMIN_SSL=${admin_ssl}
     - TRAEFIK_ADMIN_STATISTICS=${admin_statistics}
     - TRAEFIK_ADMIN_AUTH_METHOD=${admin_auth_method}
     - TRAEFIK_ADMIN_AUTH_USERS=${admin_users}
   {{- if eq .Values.acme_enable "true"}}
     - TRAEFIK_ACME_ENABLE=${acme_enable}
     - TRAEFIK_ACME_EMAIL=${acme_email}
-    - TRAEFIK_ACME_ONDEMAND=${acme_ondemand}
+    - TRAEFIK_ACME_CHALLENGE=${acme_challenge}
+    - TRAEFIK_ACME_CHALLENGE_HTTP_ENTRYPOINT=http
     - TRAEFIK_ACME_ONHOSTRULE=${acme_onhostrule}
     - TRAEFIK_ACME_CASERVER=${acme_caserver}
   {{- end}}
@@ -56,17 +64,15 @@ services:
     - TRAEFIK_CONSTRAINTS=${constraints}
     - TRAEFIK_RANCHER_HEALTHCHECK=${rancher_healthcheck}
     - TRAEFIK_RANCHER_MODE=${rancher_integration}
-    {{- if eq .Values.rancher_integration "api"}}
-    - CATTLE_URL=${cattle_url}
-    - CATTLE_ACCESS_KEY=${cattle_access_key}
-    - CATTLE_SECRET_KEY=${cattle_secret_key}
-    {{- end}}
   {{- else}}
     - TRAEFIK_FILE_ENABLE=true
   {{- end}}
-  {{- if eq .Values.prometheus_enable "true"}}
-    - TRAEFIK_PROMETHEUS_ENABLE=${prometheus_enable}
-    - TRAEFIK_PROMETHEUS_BUCKETS=${prometheus_buckets}
+  {{- if eq .Values.metrics_enable "true"}}
+    - TRAEFIK_METRICS_ENABLE=${metrics_enable}
+    - TRAEFIK_METRICS_EXPORTER=${metrics_exporter}
+    - TRAEFIK_METRICS_PUSH=${metrics_push}
+    - TRAEFIK_METRICS_ADDRESS=${metrics_address}
+    - TRAEFIK_METRICS_PROMETHEUS_BUCKETS=${metrics_prometheus_buckets}
   {{- end}}
   {{- if or (eq .Values.rancher_integration "external") (eq .Values.acme_enable "true")}}
     volumes_from:
@@ -84,7 +90,7 @@ services:
       io.rancher.scheduler.affinity:host_label: ${host_label}
       io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
       io.rancher.container.start_once: 'true'
-    image: rawmind/rancher-traefik:1.4.4-6
+    image: rawmind/rancher-traefik:1.5.0-0
     network_mode: none
     volumes:
       - tools-volume:/opt/tools

--- a/templates/traefik/17/rancher-compose.yml
+++ b/templates/traefik/17/rancher-compose.yml
@@ -1,0 +1,234 @@
+version: '2'
+catalog:
+  name: traefik
+  version: v1.5.0-rancher1
+  description: |
+    Traefik load balancer.
+  minimum_rancher_version: v0.59.0
+  maintainer: "Raul Sanchez <rawmind@gmail.com>"
+  uuid: traefik-0
+  questions:
+    - variable: "rancher_integration"
+      label: "Choose rancher integration:"
+      description: |
+        Enable rancher integration mode. Traefik built in integration, metadata or api, or external sidekick integration with confd.
+      default: metadata
+      required: true
+      type: enum
+      options:
+        - metadata
+        - api
+        - external
+    - variable: "rancher_healthcheck"
+      description: | 
+        Enable/disable rancher services healtcheck filter. If enable, just healthy services will be published.
+        Only valid for api and metadata integration. 
+      label: "Rancher healthcheck filter:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "usage_enable"
+      description: | 
+        Enable/disable send anonymous usage collection to Traefik. See https://docs.traefik.io/basics/#collected-data
+      label: "Traefik send anonymous usage:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "constraints"
+      description: |
+        Traefik constraints for rancher provider. Eg: "tag==api"
+        Only valid for api and metadata integration.
+      label: "Traefik constraints:"
+      required: false
+      default: ""
+      type: "string"
+    - variable: "host_label"
+      description: "Host label where to run traefik service."
+      label: "Host label:"
+      required: true
+      default: "traefik_lb=true" 
+      type: "string"
+    - variable: "http_port"
+      description: "Traefik http public port to listen."
+      label: "Http port:"
+      required: true
+      default: 8080
+      type: "int"
+    - variable: "https_port"
+      description: "Traefik https public port to listen."
+      label: "Https port:"
+      required: true
+      default: 8443
+      type: "int"
+    - variable: "admin_port"
+      description: "Traefik admin public port to listen for api, rest, ping and webui."
+      label: "Admin port:"
+      required: true
+      default: 8000 
+      type: "int"
+    - variable: "admin_ssl"
+      description: "Enable ssl for api, rest, ping and webui."
+      label: "Admin ssl:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "https_enable"
+      label: "Https enable:"
+      description: |
+        Enable https working mode. If you activate, you need to fill SSL key and SSL crt in order to work.
+      default: false
+      required: true
+      type: enum
+      options:
+        - false
+        - true
+        - only
+    - variable: "https_min_tls"
+      description: |
+        Minimal allowed tls version to accept connections from.
+        See the traefik documentation for allowed values. Default is `VersionTLS12`.
+      label: "Https min tls:"
+      required: false
+      default: "" 
+      type: "string"
+    - variable: "acme_enable"
+      description: "Enable acme support on traefik."
+      label: "ACME enable:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "acme_email"
+      description: "ACME user email."
+      label: "ACME email:"
+      required: true
+      default: "test@traefik.io" 
+      type: "string"
+    - variable: "acme_challenge"
+      description: "ACME challenge."
+      label: "ACME challenge:"
+      required: true
+      default: http 
+      type: enum
+      options: # List of options if using type of `enum`
+        - http
+    - variable: "acme_onhostrule"
+      description: "Enable acme onHostRule."
+      label: "ACME onHostRule:"
+      required: true
+      default: true 
+      type: "boolean"
+    - variable: "acme_caserver"
+      description: "ACME caServer to use."
+      label: "ACME caServer:"
+      required: true
+      default: "https://acme-v01.api.letsencrypt.org/directory"
+      type: "string"
+    - variable: "acme_vol_name"
+      description: "The volume name shared to store ACME certs"
+      label: "ACME Volume Name"
+      required: true
+      default: "traefik_acme_vol"
+      type: "string"
+    - variable: "acme_vol_driver"
+      description: "The volume driver shared to store ACME certs"
+      label: "ACME Volume Driver"
+      required: true
+      default: "local"
+      type: enum
+      options: # List of options if using type of `enum`
+        - local
+        - rancher-nfs
+        - rancher-efs
+        - rancher-ebs
+    - variable: "ssl_key"
+      description: "SSL key to secure the service. *Required if you enable https or admin ssl"
+      label: "Https key"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "ssl_crt"
+      description: "SSL cert to secure the service. *Required if you enable https or admin ssl"
+      label: "Https crt"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "insecure_skip"
+      description: "Enable InsecureSkipVerify param."
+      label: "InsecureSkipVerify:"
+      required: true
+      default: false 
+      type: "boolean"
+    - variable: "compress_enable"
+      label: "Enable compression:"
+      description: |
+        Enable Traefik compression for entrypoints.
+      default: true
+      required: true
+      type: "boolean"
+    - variable: "admin_statistics"
+      description: "Enable more detailed statistics."
+      label: "Admin statistics history:"
+      required: true
+      default: 10
+      type: "int"
+    - variable: "admin_auth_method"
+      description: "Admin auth method on api, rest and webui."
+      label: "Admin auth method:"
+      required: true
+      default: "basic"
+      type: enum
+      options: # List of options if using type of `enum`
+        - basic
+        - digest
+    - variable: "admin_users"
+      description: "Admin auth user list on api, rest and webui. Generate with htpassword for basic or htdigest with traefik realm for digest."
+      label: "Admin users:"
+      type: "multiline"
+      required: false
+      default: ""
+    - variable: "metrics_enable"
+      description: "Enable traefik metrics."
+      label: "Metrics enable"
+      default: false
+      required: true
+      type: "boolean"
+    - variable: "metrics_exporter"
+      description: "Traefik metrics exporter."
+      label: "Metrics exporter:"
+      required: false
+      default: 
+      type: enum
+      options: # List of options if using type of `enum`
+        - prometheus
+        - datadog
+        - statsd
+        - influxdb
+    - variable: "metrics_push"
+      description: "Traefik metrics exporter push interval. Apply on datadog, statsd and influxdb."
+      label: "Metrics push interval (s):"
+      required: false
+      default: 10 
+      type: "int"
+    - variable: "metrics_address"
+      description: "Traefik metrics exporter address to push. Apply on datadog, statsd and influxdb."
+      label: "Metrics address:"
+      required: false
+      default: ""
+      type: "string"
+    - variable: "metrics_prometheus_buckets"
+      description: "Traefik metrics buckets for prometheus."
+      label: "Metrics prometheus buckets"
+      default: "[0.1,0.3,1.2,5.0]"
+      required: false
+      type: "string"
+services:
+  traefik:
+    retain_ip: true
+    health_check:
+      healthy_threshold: 2
+      response_timeout: 5000
+      port: 8000
+      unhealthy_threshold: 3
+      interval: 5000
+      strategy: recreate
+

--- a/templates/traefik/config.yml
+++ b/templates/traefik/config.yml
@@ -1,7 +1,7 @@
 name: Traefik
 description: |
   Traefik active load balancer
-version: v1.4.6-rancher1
+version: v1.5.0-rancher1
 category: Load Balancing
 maintainer: "Raul Sanchez <rawmind@gmail.com>"
 minimum_rancher_version: v0.59.0


### PR DESCRIPTION
Traefik updated to v1.5.0 and added new features
- Updated config to v1.5.0 avoiding deprecated parameters.
- Enable ssl on api, rest, ping and webui.
- Added metrics exporters integration prometheus, datadog, statsd, influxdb.
- Updated acme challenge to http. Issues https://github.com/containous/traefik/issues/1832, https://github.com/rawmind0/alpine-traefik/issues/74