### PR TITLE
hetzner: fixed dead link

### DIFF
--- a/machine-templates/hetzner/0/uiUrl
+++ b/machine-templates/hetzner/0/uiUrl
@@ -1,1 +1,1 @@
-https://maxibanki.github.io/ui-driver-hetzner/dist/component.js
+https://mxschmitt.github.io/ui-driver-hetzner/dist/component.js


### PR DESCRIPTION
Hi,
unfortunately I renamed my account yesterday, so the ui-driver has dead links. I'm not sure what better is, just a fix to the existing version or create a new one with the new url.
Best regards and sorry
Max