### PR TITLE
Fix healthcheck and add DB host configuration

### DIFF
--- a/templates/sentry/4/README.md
+++ b/templates/sentry/4/README.md
@@ -1,0 +1,20 @@
+# Sentry
+
+
+### Info:
+ This templates creates a complete [sentry](https://github.com/getsentry/sentry) setup including postgres and redis servers.
+
+ Images are the offical images from:
+ * Sentry: [https://hub.docker.com/_/sentry/](https://hub.docker.com/_/sentry/)
+ * Postgres: [https://hub.docker.com/_/postgres/](https://hub.docker.com/_/postgres/)
+ * Redis: [https://hub.docker.com/_/redis/](https://hub.docker.com/_/redis/)
+
+### Usage:
+
+ * Select Sentry from catalog.
+
+ * Required: Enter a sentry secret
+
+ * Optional: Email configuration
+
+ * Click deploy.

--- a/templates/sentry/4/README.md
+++ b/templates/sentry/4/README.md
@@ -13,8 +13,14 @@
 
  * Select Sentry from catalog.
 
- * Required: Enter a sentry secret
+ * Required
+   * Enter a sentry secret
+   * Specify the email and password of the initial user
 
- * Optional: Email configuration
+ * Optional
+   * Specify an external database host \*
+   * Email configuration
 
  * Click deploy.
+
+\* If you specify an external database, you will want to delete the "sentry-postgres" service after creating the Sentry stack.

--- a/templates/sentry/4/docker-compose.yml
+++ b/templates/sentry/4/docker-compose.yml
@@ -1,0 +1,114 @@
+sentry-postgres:
+  environment:
+    POSTGRES_DB: ${sentry_db_name}
+    POSTGRES_USER: ${sentry_db_user}
+    POSTGRES_PASSWORD: ${sentry_db_pass}
+    PGDATA: /data/postgres/data
+  log_driver: ''
+  labels:
+    io.rancher.sidekicks: sentry-postgres-datavolume
+    io.rancher.container.hostname_override: container_name
+  volumes_from:
+    - sentry-postgres-datavolume
+  tty: true
+  log_opt: {}
+  image: postgres:9.6-alpine
+  stdin_open: true
+sentry-postgres-datavolume:
+  image: alpine
+  stdin_open: true
+  net: none
+  entrypoint:
+  - /bin/true
+  volumes:
+  - /data/postgres/data
+  tty: true
+  labels:
+    io.rancher.container.start_once: 'true'
+sentry-cron:
+  environment:
+    SENTRY_EMAIL_HOST: ${sentry_email_host}
+    SENTRY_EMAIL_PASSWORD: ${sentry_email_password}
+    SENTRY_EMAIL_PORT: '${sentry_email_port}'
+    SENTRY_EMAIL_USER: ${sentry_email_user}
+    SENTRY_SECRET_KEY: ${sentry_secret_key}
+    SENTRY_SERVER_EMAIL: ${sentry_server_email}
+    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_DB_NAME: ${sentry_db_name}
+    SENTRY_DB_USER: ${sentry_db_user}
+    SENTRY_DB_PASSWORD: ${sentry_db_pass}
+  log_driver: ''
+  labels:
+    io.rancher.container.hostname_override: container_name
+  tty: true
+  command:
+  - run
+  - cron
+  log_opt: {}
+  image: sentry:8.21.0
+  links:
+  - sentry-postgres:postgres
+  - sentry-redis:redis
+  stdin_open: true
+sentry-redis:
+  log_driver: ''
+  labels:
+    io.rancher.container.hostname_override: container_name
+  tty: true
+  log_opt: {}
+  image: redis:3.2-alpine
+  stdin_open: true
+sentry:
+  ports:
+  - ${sentry_public_port}:9000/tcp
+  environment:
+    SENTRY_EMAIL_HOST: ${sentry_email_host}
+    SENTRY_EMAIL_PASSWORD: ${sentry_email_password}
+    SENTRY_EMAIL_PORT: '${sentry_email_port}'
+    SENTRY_EMAIL_USER: ${sentry_email_user}
+    SENTRY_SECRET_KEY: ${sentry_secret_key}
+    SENTRY_SERVER_EMAIL: ${sentry_server_email}
+    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_DB_NAME: ${sentry_db_name}
+    SENTRY_DB_USER: ${sentry_db_user}
+    SENTRY_DB_PASSWORD: ${sentry_db_pass}
+  log_driver: ''
+  labels:
+    io.rancher.container.hostname_override: container_name
+  tty: true
+  command:
+  - /bin/bash
+  - -c
+  - sentry upgrade --noinput && sentry createuser --email ${sentry_initial_user_email} --password ${sentry_initial_user_password} --superuser && /entrypoint.sh run web || /entrypoint.sh run web
+  log_opt: {}
+  image: sentry:8.21.0
+  links:
+  - sentry-postgres:postgres
+  - sentry-redis:redis
+  stdin_open: true
+sentry-worker:
+  environment:
+    SENTRY_EMAIL_HOST: ${sentry_email_host}
+    SENTRY_EMAIL_PASSWORD: ${sentry_email_password}
+    SENTRY_EMAIL_PORT: '${sentry_email_port}'
+    SENTRY_EMAIL_USER: ${sentry_email_user}
+    SENTRY_SECRET_KEY: ${sentry_secret_key}
+    SENTRY_SERVER_EMAIL: ${sentry_server_email}
+    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_DB_NAME: ${sentry_db_name}
+    SENTRY_DB_USER: ${sentry_db_user}
+    SENTRY_DB_PASSWORD: ${sentry_db_pass}
+  log_driver: ''
+  labels:
+    io.rancher.scheduler.global: 'true'
+    io.rancher.container.hostname_override: container_name
+  tty: true
+  command:
+  - run
+  - worker
+  log_opt: {}
+  image: sentry:8.21.0
+  links:
+  - sentry-postgres:postgres
+  - sentry-redis:redis
+  stdin_open: true

--- a/templates/sentry/4/docker-compose.yml
+++ b/templates/sentry/4/docker-compose.yml
@@ -33,7 +33,7 @@ sentry-cron:
     SENTRY_EMAIL_USER: ${sentry_email_user}
     SENTRY_SECRET_KEY: ${sentry_secret_key}
     SENTRY_SERVER_EMAIL: ${sentry_server_email}
-    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_POSTGRES_HOST: ${sentry_db_host}
     SENTRY_DB_NAME: ${sentry_db_name}
     SENTRY_DB_USER: ${sentry_db_user}
     SENTRY_DB_PASSWORD: ${sentry_db_pass}
@@ -68,7 +68,7 @@ sentry:
     SENTRY_EMAIL_USER: ${sentry_email_user}
     SENTRY_SECRET_KEY: ${sentry_secret_key}
     SENTRY_SERVER_EMAIL: ${sentry_server_email}
-    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_POSTGRES_HOST: ${sentry_db_host}
     SENTRY_DB_NAME: ${sentry_db_name}
     SENTRY_DB_USER: ${sentry_db_user}
     SENTRY_DB_PASSWORD: ${sentry_db_pass}
@@ -94,7 +94,7 @@ sentry-worker:
     SENTRY_EMAIL_USER: ${sentry_email_user}
     SENTRY_SECRET_KEY: ${sentry_secret_key}
     SENTRY_SERVER_EMAIL: ${sentry_server_email}
-    SENTRY_POSTGRES_HOST: postgres
+    SENTRY_POSTGRES_HOST: ${sentry_db_host}
     SENTRY_DB_NAME: ${sentry_db_name}
     SENTRY_DB_USER: ${sentry_db_user}
     SENTRY_DB_PASSWORD: ${sentry_db_pass}

--- a/templates/sentry/4/rancher-compose.yml
+++ b/templates/sentry/4/rancher-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 catalog:
   name: Sentry
-  version: 8.21.0
+  version: 8.21.0-1
   description: Sentry is a realtime event logging and aggregation platform
 
   questions:

--- a/templates/sentry/4/rancher-compose.yml
+++ b/templates/sentry/4/rancher-compose.yml
@@ -18,6 +18,14 @@ catalog:
       default: 9000
       description: "Port that Sentry will listen on. Alternatively you could point a load balancer to the port 9000 of this container"
 
+    - variable: "sentry_db_host"
+      type: "string"
+      required: true
+      label: "Sentry db host"
+      default: "postgres"
+      description: "Sentry db host."
+
+
     - variable: "sentry_db_name"
       type: "string"
       required: true

--- a/templates/sentry/4/rancher-compose.yml
+++ b/templates/sentry/4/rancher-compose.yml
@@ -1,0 +1,129 @@
+version: '2'
+catalog:
+  name: Sentry
+  version: 8.21.0
+  description: Sentry is a realtime event logging and aggregation platform
+
+  questions:
+    - variable: "sentry_secret_key"
+      type: "password"
+      required: true
+      label: "SENTRY_SECRET_KEY"
+      description: "A secret key used for cryptographic functions within Sentry. see https://hub.docker.com/_/sentry/ for more info"
+
+    - variable: "sentry_public_port"
+      type: "int"
+      required: true
+      label: "Sentry public port"
+      default: 9000
+      description: "Port that Sentry will listen on. Alternatively you could point a load balancer to the port 9000 of this container"
+
+    - variable: "sentry_db_name"
+      type: "string"
+      required: true
+      label: "Sentry db name"
+      default: "sentry"
+      description: "Sentry db name."
+
+    - variable: "sentry_db_user"
+      type: "string"
+      required: true
+      label: "Sentry db user"
+      default: "sentry"
+      description: "Sentry db user."
+
+    - variable: "sentry_db_pass"
+      type: "string"
+      required: true
+      label: "Sentry db pass"
+      default: "sentry"
+      description: "Sentry db pass."
+
+    - variable: "sentry_initial_user_email"
+      type: "string"
+      required: true
+      label: "SENTRY_INITIAL_USER_EMAIL"
+      description: "The initial superuser email"
+
+    - variable: "sentry_initial_user_password"
+      type: "password"
+      required: true
+      label: "SENTRY_INITIAL_USER_PASSWORD"
+      description: "The initial superuser password. Please use a simple initial password and change it afterwards in the Sentry interface"
+
+    - variable: "sentry_server_email"
+      type: "string"
+      required: false
+      label: "SENTRY_SERVER_EMAIL"
+      description: "The email address used for 'From:'. see https://hub.docker.com/_/sentry/ for more info"
+
+    - variable: "sentry_email_host"
+      type: "string"
+      required: false
+      label: "SENTRY_EMAIL_HOST"
+      description: "The smtp server address. see https://hub.docker.com/_/sentry/ for more info"
+
+    - variable: "sentry_email_user"
+      type: "string"
+      required: false
+      label: "SENTRY_EMAIL_USER"
+      description: "The username for the email account. see https://hub.docker.com/_/sentry/ for more info"
+
+    - variable: "sentry_email_password"
+      type: "password"
+      required: false
+      label: "SENTRY_EMAIL_PASSWORD"
+      description: "The password for the email account. see https://hub.docker.com/_/sentry/ for more info"
+
+    - variable: "sentry_email_port"
+      type: "int"
+      required: false
+      label: "SENTRY_EMAIL_PORT"
+      description: "Port of the smtp server. see https://hub.docker.com/_/sentry/ for more info"
+
+services:
+  sentry-cron:
+    scale: 1
+    start_on_create: true
+  sentry-postgres-datavolume:
+    scale: 1
+    start_on_create: true
+  sentry-worker:
+    start_on_create: true
+  sentry-redis:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 2000
+      healthy_threshold: 2
+      port: 6379
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      strategy: recreate
+      reinitializing_timeout: 60000
+  sentry-postgres:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 2000
+      healthy_threshold: 2
+      port: 5432
+      unhealthy_threshold: 3
+      initializing_timeout: 60000
+      interval: 2000
+      strategy: recreate
+      reinitializing_timeout: 60000
+  sentry:
+    scale: 1
+    start_on_create: true
+    health_check:
+      response_timeout: 2000
+      healthy_threshold: 2
+      port: 9000
+      unhealthy_threshold: 3
+      initializing_timeout: 600000
+      interval: 2000
+      strategy: recreate
+      request_line: GET "/_health/" "HTTP/1.0"
+      reinitializing_timeout: 60000

--- a/templates/sentry/config.yml
+++ b/templates/sentry/config.yml
@@ -1,4 +1,4 @@
 name: Sentry
-version: 8.21.0
+version: 8.21.0-1
 description: Sentry is a realtime event logging and aggregation platform
 category: Error Tracking


### PR DESCRIPTION
- The current healthcheck is `/auth/login/sentry` which spams the logs with 301 redirects because Sentry expects a canonical trailing slash.
- Updates the healthcheck to `/_health/` which is [described in the docs](https://docs.sentry.io/server/monitoring/) as the correct way to verify the web app health.
- Adds a `sentry_db_host` configuration setting (which defaults to the existing `sentry-postgres` service), to allow for using an external database from initial setup.