### PR TITLE
letsencrypt: Allow optional `external: true` in volume

### DIFF
--- a/templates/letsencrypt/4/docker-compose.yml.tpl
+++ b/templates/letsencrypt/4/docker-compose.yml.tpl
@@ -54,6 +54,9 @@ volumes:
   {{.Values.VOLUME_NAME}}:
     {{- if .Values.STORAGE_DRIVER}}
     driver: {{.Values.STORAGE_DRIVER}}
+    {{- if eq .Values.STORAGE_EXTERNAL "true"}}
+    external: true
+    {{- end }}
     {{- if .Values.STORAGE_DRIVER_OPT}}
     driver_opts:
       {{.Values.STORAGE_DRIVER_OPT}}

--- a/templates/letsencrypt/4/rancher-compose.yml
+++ b/templates/letsencrypt/4/rancher-compose.yml
@@ -100,6 +100,13 @@
         of an existing storage driver (see `Infrastructure -> Storage`). This also requires "Volume Name" to be set.
       required: false
       type: string
+    - variable: STORAGE_EXTERNAL
+      label:  Volume External (Optional)
+      description: |
+        Add `external: true` volume option to share it across stacks.
+      required: false
+      type: boolean
+      default: false
     - variable: STORAGE_DRIVER_OPT
       label: Storage Driver Option (Optional)
       description: |


### PR DESCRIPTION
Allows the volume to have a `external: true` if needed so the certificate can be shared across stacks.
My use case for this is that the certificate is needed by a smtp forwarder container.

In case this is something wanted, since the change is backward compatible I am not sure whether is appropriate to overwrite the latest version or create a new version template.