### PR TITLE
Remove traefikdomain because it was never defined

### DIFF
--- a/templates/project-harbor/4/docker-compose.yml
+++ b/templates/project-harbor/4/docker-compose.yml
@@ -47,7 +47,7 @@ services:
     image: mreferre/harbor-setupwrapper:1.1.1-1
     container_name: harbor-setupwrapper
     environment:
-      - HARBORHOSTNAME=${harborhostname}.${traefikdomain}
+      - HARBORHOSTNAME=${harborhostname}
       - HARBOR_ADMIN_PASSWORD=${harbor_admin_password}
     volumes:
       - data:/data


### PR DESCRIPTION
This variable creates an error in configuration files:

```
configadmin...env:2:EXT_ENDPOINT=http://domain.
data...config.json:14:  "ext_endpoint": "http://domain.",
registry...config.yml:24:    realm: http://domain./service/token
```

This makes UI works well, but you will never login with
docker login or pull something public.

Once this variable was never defined, I removed it.
Than works everything fine.

Closes #707 