### PR TITLE
Logstash: logstash-collector requires elasticsearch link

### DIFF
--- a/templates/logstash/4/docker-compose.yml
+++ b/templates/logstash/4/docker-compose.yml
@@ -38,6 +38,8 @@ logstash-collector:
   tty: true
   links:
   - redis:redis
+  external_links:
+  - ${elasticsearch_link}:elasticsearch
   ports:
   - "5000/udp"
   - "6000/tcp"


### PR DESCRIPTION
The logstash-collector as well requires elasticsearch link.

Reason: It checks the license on elasticsearch. If that link is not set, it will log the following all the time:
```
19/04/2018 11:35:17[2018-04-19T09:35:17,916][ERROR][logstash.licensechecker.licensemanager] Unable to retrieve license information from license server {:message=>"No Available connections", :class=>"LogStash::Outputs::ElasticSearch::HttpClient::Pool::NoConnectionAvailableError"}
19/04/2018 11:35:17[2018-04-19T09:35:17,916][WARN ][logstash.licensechecker.xpackinfo] Nil response from License Server
19/04/2018 11:35:17[2018-04-19T09:35:17,926][INFO ][logstash.outputs.elasticsearch] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@elasticsearch:9200/, :path=>"/"}
19/04/2018 11:35:17[2018-04-19T09:35:17,929][WARN ][logstash.outputs.elasticsearch] Attempted to resurrect connection to dead ES instance, but got an error. {:url=>"http://logstash_system:xxxxxx@elasticsearch:9200/", :error_type=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :error=>"Elasticsearch Unreachable: [http://logstash_system:xxxxxx@elasticsearch:9200/][Manticore::ResolutionFailure] elasticsearch: Name or service not known"}
19/04/2018 11:35:17[2018-04-19T09:35:17,985][INFO ][logstash.licensechecker.licensereader] Running health check to see if an Elasticsearch connection is working {:healthcheck_url=>http://logstash_system:xxxxxx@elasticsearch:9200/, :path=>"/"}
19/04/2018 11:35:17[2018-04-19T09:35:17,987][WARN ][logstash.licensechecker.licensereader] Attempted to resurrect connection to dead ES instance, but got an error. {:url=>"http://logstash_system:xxxxxx@elasticsearch:9200/", :error_type=>LogStash::Outputs::ElasticSearch::HttpClient::Pool::HostUnreachableError, :error=>"Elasticsearch Unreachable: [http://logstash_system:xxxxxx@elasticsearch:9200/][Manticore::ResolutionFailure] elasticsearch"}
```

## Workaround for now:
After creating the stack, upgrade `logstash-collector` and add a `Service Links` to `es-client` with name `elasticsearch`.