### PR TITLE
Updated es-cluster package to work on rancher v1.6.15 and higher

### DIFF
--- a/templates/es-cluster/0/rancher-compose.yml
+++ b/templates/es-cluster/0/rancher-compose.yml
@@ -2,6 +2,7 @@
     name: Elasticsearch Cluster
     version: 5.4.0-rancher1
     description: Scalable Elasticsearch Cluster
+    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"

--- a/templates/es-cluster/1/rancher-compose.yml
+++ b/templates/es-cluster/1/rancher-compose.yml
@@ -2,6 +2,7 @@
     name: Elasticsearch Cluster
     version: 5.4.2-rancher1
     description: Scalable Elasticsearch Cluster
+    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"

--- a/templates/es-cluster/3/rancher-compose.yml
+++ b/templates/es-cluster/3/rancher-compose.yml
@@ -3,6 +3,7 @@ catalog:
     name: Elasticsearch Cluster
     version: 5.5.1-rancher1
     description: Scalable Elasticsearch Cluster
+    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"

--- a/templates/es-cluster/4/rancher-compose.yml
+++ b/templates/es-cluster/4/rancher-compose.yml
@@ -3,6 +3,7 @@ catalog:
     name: Elasticsearch Cluster
     version: 6.2.3-rancher1
     description: Scalable Elasticsearch Cluster
+    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"

--- a/templates/es-cluster/5/README.md
+++ b/templates/es-cluster/5/README.md
@@ -1,0 +1,5 @@
+# Elasticsearch Cluster
+
+A scalable Elasticsearch cluster
+
+WARN: To avoid vm.max_map_count errors you could set "Update host sysctl" to true. Then param vm.max_map_count will be update to 262144 if it's less in your hosts.

--- a/templates/es-cluster/5/docker-compose.yml.tpl
+++ b/templates/es-cluster/5/docker-compose.yml.tpl
@@ -1,0 +1,152 @@
+version: '2'
+services:
+    es-master:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-master-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "ES_JAVA_OPTS=-Xms${master_heap_size} -Xmx${master_heap_size}"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "discovery.zen.minimum_master_nodes=${minimum_master_nodes}"
+            - "node.master=true"
+            - "node.data=false"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${master_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-master-storage
+
+    es-master-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-master-volume:/usr/share/elasticsearch/data
+
+    es-data:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-data-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "ES_JAVA_OPTS=-Xms${data_heap_size} -Xmx${data_heap_size}"
+            - "node.master=false"
+            - "node.data=true"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${data_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-data-storage
+        depends_on:
+            - es-master
+
+    es-data-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-data-volume:/usr/share/elasticsearch/data
+
+    es-client:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-client-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:5.5.1
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "ES_JAVA_OPTS=-Xms${client_heap_size} -Xmx${client_heap_size}"
+            - "node.master=false"
+            - "node.data=false"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${client_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-client-storage
+        depends_on:
+            - es-master
+
+    es-client-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-client-volume:/usr/share/elasticsearch/data
+
+    {{- if eq .Values.UPDATE_SYSCTL "true" }}
+    es-sysctl:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-sysctl:0.1
+        privileged: true
+        environment:
+            - "SYSCTL_KEY=vm.max_map_count"
+            - "SYSCTL_VALUE=262144"
+    {{- end}}
+
+volumes:
+  es-master-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true
+  es-data-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true
+  es-client-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true

--- a/templates/es-cluster/5/rancher-compose.yml
+++ b/templates/es-cluster/5/rancher-compose.yml
@@ -1,9 +1,8 @@
 version: '2'
 catalog:
     name: Elasticsearch Cluster
-    version: 5.4.2-rancher2
+    version: 5.5.1-rancher2
     description: Scalable Elasticsearch Cluster
-    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"
@@ -29,7 +28,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (master nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (master nodes)"
           default: "512m"
 
         - variable: "master_mem_limit"
@@ -43,7 +42,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (data nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (data nodes)"
           default: "512m"
 
         - variable: "data_mem_limit"
@@ -57,7 +56,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (client nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (client nodes)"
           default: "512m"
 
         - variable: "client_mem_limit"

--- a/templates/es-cluster/6/README.md
+++ b/templates/es-cluster/6/README.md
@@ -1,0 +1,5 @@
+# Elasticsearch Cluster
+
+A scalable Elasticsearch cluster
+
+WARN: To avoid vm.max_map_count errors you could set "Update host sysctl" to true. Then param vm.max_map_count will be update to 262144 if it's less in your hosts.

--- a/templates/es-cluster/6/docker-compose.yml.tpl
+++ b/templates/es-cluster/6/docker-compose.yml.tpl
@@ -1,0 +1,152 @@
+version: '2'
+services:
+    es-master:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-master-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "ES_JAVA_OPTS=-Xms${master_heap_size} -Xmx${master_heap_size}"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "discovery.zen.minimum_master_nodes=${minimum_master_nodes}"
+            - "node.master=true"
+            - "node.data=false"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${master_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-master-storage
+
+    es-master-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-master-volume:/usr/share/elasticsearch/data
+
+    es-data:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-data-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "ES_JAVA_OPTS=-Xms${data_heap_size} -Xmx${data_heap_size}"
+            - "node.master=false"
+            - "node.data=true"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${data_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-data-storage
+        depends_on:
+            - es-master
+
+    es-data-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-data-volume:/usr/share/elasticsearch/data
+
+    es-client:
+        labels:
+            io.rancher.scheduler.affinity:container_label_soft_ne: io.rancher.stack_service.name=$${stack_name}/$${service_name}
+            io.rancher.container.hostname_override: container_name
+            io.rancher.sidekicks: es-client-storage{{- if eq .Values.UPDATE_SYSCTL "true" -}},es-sysctl{{- end}}
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+        environment:
+            - "cluster.name=${cluster_name}"
+            - "node.name=$${HOSTNAME}"
+            - "bootstrap.memory_lock=true"
+            - "xpack.security.enabled=false"
+            - "discovery.zen.ping.unicast.hosts=es-master"
+            - "ES_JAVA_OPTS=-Xms${client_heap_size} -Xmx${client_heap_size}"
+            - "node.master=false"
+            - "node.data=false"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        mem_limit: ${client_mem_limit}
+        mem_swappiness: 0
+        cap_add:
+            - IPC_LOCK
+        volumes_from:
+            - es-client-storage
+        depends_on:
+            - es-master
+
+    es-client-storage:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-volume:0.0.2-1
+        environment:
+            - SERVICE_UID=1000
+            - SERVICE_GID=1000
+            - SERVICE_VOLUME=/usr/share/elasticsearch/data
+        volumes:
+            - es-client-volume:/usr/share/elasticsearch/data
+
+    {{- if eq .Values.UPDATE_SYSCTL "true" }}
+    es-sysctl:
+        labels:
+            io.rancher.container.start_once: true
+        network_mode: none
+        image: rawmind/alpine-sysctl:0.1
+        privileged: true
+        environment:
+            - "SYSCTL_KEY=vm.max_map_count"
+            - "SYSCTL_VALUE=262144"
+    {{- end}}
+
+volumes:
+  es-master-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true
+  es-data-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true
+  es-client-volume:
+    driver: ${VOLUME_DRIVER}
+    per_container: true

--- a/templates/es-cluster/6/rancher-compose.yml
+++ b/templates/es-cluster/6/rancher-compose.yml
@@ -1,9 +1,8 @@
 version: '2'
 catalog:
     name: Elasticsearch Cluster
-    version: 5.4.2-rancher2
+    version: 6.2.3-rancher2
     description: Scalable Elasticsearch Cluster
-    maximum_rancher_version: v1.6.14
 
     questions:
         - variable: "cluster_name"
@@ -29,7 +28,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (master nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (master nodes)"
           default: "512m"
 
         - variable: "master_mem_limit"
@@ -43,7 +42,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (data nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (data nodes)"
           default: "512m"
 
         - variable: "data_mem_limit"
@@ -57,7 +56,7 @@ catalog:
           type: "string"
           required: true
           label: "Heap size (client nodes)"
-          description: "Heap size to be allocated for Java (mater nodes)"
+          description: "Heap size to be allocated for Java (client nodes)"
           default: "512m"
 
         - variable: "client_mem_limit"

--- a/templates/es-cluster/config.yml
+++ b/templates/es-cluster/config.yml
@@ -1,5 +1,5 @@
 name: Elasticsearch Cluster 6.2.3
 description: |
   Elasticsearch, you know for search!
-version: 6.2.3-rancher1
+version: 6.2.3-rancher2
 category: ELK


### PR DESCRIPTION
Due to merged PR https://github.com/rancher/rancher-compose-executor/pull/143, es-cluster is failing to deploy on rancher v1.6.15 and higher, issue https://github.com/rancher/community-catalog/issues/756

This PR rewrite 2 last es-cluster versions to be deployable on rancher v1.6.15 and higher and set `maximum_rancher_version: v1.6.14` on previous versions.