### PR TITLE
fix wordpress package lb

### DIFF
--- a/templates/wordpress/1/rancher-compose.yml
+++ b/templates/wordpress/1/rancher-compose.yml
@@ -72,6 +72,7 @@ services:
     health_check:
       response_timeout: 2000
       healthy_threshold: 2
+      interval: 2000
       port: 42
       unhealthy_threshold: 3
   wordpress:


### PR DESCRIPTION
According https://github.com/rancher/rancher/issues/8538 there is a bug in LB causes to generate invalid configuration when interval option is not set. This invalid config causes LB fail to reload/start.

It happens when upgrading wordpress load balancer to docker:rancher/lb-service-haproxy:v0.9.1.
