### PR TITLE
Fix es-cluster when using with rancher-ebs volume driver

### DIFF
--- a/templates/es-cluster/7/docker-compose.yml.tpl
+++ b/templates/es-cluster/7/docker-compose.yml.tpl
@@ -161,10 +161,16 @@ services:
 volumes:
   es-master-volume:
     driver: ${VOLUME_DRIVER}
+    driver_opts:
+      {{.Values.VOLUME_DRIVER_OPTS}}
     per_container: true
   es-data-volume:
     driver: ${VOLUME_DRIVER}
+    driver_opts:
+      {{.Values.VOLUME_DRIVER_OPTS}}
     per_container: true
   es-client-volume:
     driver: ${VOLUME_DRIVER}
+    driver_opts:
+      {{.Values.VOLUME_DRIVER_OPTS}}
     per_container: true

--- a/templates/es-cluster/7/rancher-compose.yml
+++ b/templates/es-cluster/7/rancher-compose.yml
@@ -99,6 +99,15 @@ catalog:
             - rancher-efs
             - rancher-ebs
 
+        - variable: "VOLUME_DRIVER_OPTS"
+          description: "VOLUME driver option"
+          description: |
+            Specify a single "driver_opts" key/value pair in the format "optionName: optionValue".
+            E.g. for the `rancher-ebs` driver you should specify the required 'size' option like this: "size: 1".
+          label: "Volume Driver Option (Optional)"
+          required: false
+          type: string
+
 services:
 
   es-master:


### PR DESCRIPTION
rancher-ebs volume driver requires `size` driver_opts