### PR TITLE
Allow customizing Jenkins path prefix

### DIFF
--- a/templates/jenkins-ci/4/docker-compose.yml
+++ b/templates/jenkins-ci/4/docker-compose.yml
@@ -8,7 +8,7 @@ jenkins-primary:
   volumes_from:
     - jenkins-plugins
     - jenkins-datavolume
-  env:
+  environment:
     JENKINS_OPTS: "--prefix=${prefix}"
   entrypoint: /usr/share/jenkins/rancher/jenkins.sh
 jenkins-plugins:

--- a/templates/jenkins-ci/4/docker-compose.yml
+++ b/templates/jenkins-ci/4/docker-compose.yml
@@ -8,6 +8,8 @@ jenkins-primary:
   volumes_from:
     - jenkins-plugins
     - jenkins-datavolume
+  env:
+    JENKINS_OPTS: "--prefix=${prefix}"
   entrypoint: /usr/share/jenkins/rancher/jenkins.sh
 jenkins-plugins:
   image: rancher/jenkins-plugins:v0.1.1

--- a/templates/jenkins-ci/4/rancher-compose.yml
+++ b/templates/jenkins-ci/4/rancher-compose.yml
@@ -11,6 +11,8 @@
     default: 8080
     required: true
   - variable: "prefix"
+    type: "string"
+    label: "Path prefix"
     description: "Which path prefix should Jenkins base its URLs on?"
     required: true
     default: "/"

--- a/templates/jenkins-ci/4/rancher-compose.yml
+++ b/templates/jenkins-ci/4/rancher-compose.yml
@@ -10,6 +10,10 @@
     description: "Which port should Jenkins listen on?"
     default: 8080
     required: true
+  - variable: "prefix"
+    description: "Which path prefix should Jenkins base its URLs on?"
+    required: true
+    default: "/"
   - variable: "volume_work"
     description: "Work volume to save jenkins data"
     label: "Work volume:"


### PR DESCRIPTION
When deploying Jenkins behind a reverse proxy, often it's deployed behind a path prefix (example.com/jenkins).

This PR allows adding and customizing that prefix in Rancher.

(This is my first PR to Rancher catalogs, please let me know if I screwed something up!)