### PR TITLE
Upgrade GitLab multi runner to version 11.2.0

### DIFF
--- a/templates/gitlab-multi-runner/5/docker-compose.yml.tpl
+++ b/templates/gitlab-multi-runner/5/docker-compose.yml.tpl
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gitlab-runner-config:
-    image: gitlab/gitlab-runner:alpine-v11.1.0
+    image: gitlab/gitlab-runner:alpine-v11.2.0
     stdin_open: true
     volumes:
     - /etc/gitlab-runner/
@@ -40,7 +40,7 @@ services:
       io.rancher.container.start_once: 'true'
 
   gitlab-runner:
-    image: gitlab/gitlab-runner:alpine-v11.1.0
+    image: gitlab/gitlab-runner:alpine-v11.2.0
     stdin_open: true
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock

--- a/templates/gitlab-multi-runner/5/docker-compose.yml.tpl
+++ b/templates/gitlab-multi-runner/5/docker-compose.yml.tpl
@@ -1,0 +1,57 @@
+version: '2'
+
+services:
+
+  gitlab-runner-config:
+    image: gitlab/gitlab-runner:alpine-v11.1.0
+    stdin_open: true
+    volumes:
+    - /etc/gitlab-runner/
+    tty: true
+    command:
+    - register
+    - -n
+    - --url
+    - ${GITLAB_URL}
+    - --registration-token
+    - ${GITLAB_TOKEN}
+    - --tag-list
+    - ${GITLAB_TAGS}
+    - --executor
+    - docker
+    - --description
+    - Rancher Docker Runner
+    - --docker-image
+    - docker:latest
+    - --docker-volumes
+    - /var/run/docker.sock:/var/run/docker.sock
+    - --docker-privileged
+    labels:
+      io.rancher.container.start_once: 'true'
+
+  gitlab-runner-config-edit:
+    image: busybox:latest
+    volumes_from:
+    - gitlab-runner-config
+    tty: true
+    command: sed -i -e "s|concurrent = 1|concurrent = ${CONCURRENT}|g" /etc/gitlab-runner/config.toml
+    network_mode: none
+    labels:
+      io.rancher.container.start_once: 'true'
+
+  gitlab-runner:
+    image: gitlab/gitlab-runner:alpine-v11.1.0
+    stdin_open: true
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    tty: true
+    volumes_from:
+    - gitlab-runner-config-edit
+    command:
+    - run
+    labels:
+      io.rancher.sidekicks: gitlab-runner-config, gitlab-runner-config-edit
+      io.rancher.scheduler.global: 'true'
+    {{- if ne .Values.host_label ""}}
+      io.rancher.scheduler.affinity:host_label: ${host_label}
+    {{- end}}

--- a/templates/gitlab-multi-runner/5/rancher-compose.yml
+++ b/templates/gitlab-multi-runner/5/rancher-compose.yml
@@ -1,0 +1,54 @@
+version: '2'
+
+catalog:
+  name: "gitlab-multi-runner"
+  version: "11.1.0"
+  description: "a Gitlab pipelines multi-runner, that will spawn privates runners in your infra."
+  minimum_rancher_version: v1.5.0
+  # maximum_rancher_version:
+  # upgrade_from: # The previous versions that this template can be upgraded from
+  questions:
+    - variable: "GITLAB_URL"
+      label: "Gitlab Url"
+      description: "Url to your Gitlab CI endpoint"
+      type: "string"
+      default: "https://gitlab.com/ci"
+      required: true
+
+    - variable: "GITLAB_TOKEN"
+      label: "Gitlab Token"
+      description: "Token provided in you project settings"
+      type: "string"
+      default: "xxxxxxxxxxxxxxxxxxxx"
+      required: true
+
+    - variable: "GITLAB_TAGS"
+      label: "Gitlab Tags"
+      description: "Tags to apply"
+      type: "string"
+      default: "dev"
+      required: false
+
+    - variable: "host_label"
+      label: "Host with Label to deploy gitlab-runner on"
+      description: |
+        Host label to use as gitlab-runner 'value' tag.
+        Example: 'gitlab-runner=true'
+      type: "string"
+      default: ""
+      required: false
+
+    - variable: "CONCURRENT"
+      label: "Concurrent"
+      description: "Limits how many jobs globally can be run concurrently"
+      type: "string"
+      default: "1"
+      required: true
+
+services:
+  gitlab-runner-config:
+    start_on_create: true
+  gitlab-runner-config-edit:
+    start_on_create: true
+  gitlab-runner:
+    start_on_create: true

--- a/templates/gitlab-multi-runner/5/rancher-compose.yml
+++ b/templates/gitlab-multi-runner/5/rancher-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 
 catalog:
   name: "gitlab-multi-runner"
-  version: "11.1.0"
+  version: "11.2.0"
   description: "a Gitlab pipelines multi-runner, that will spawn privates runners in your infra."
   minimum_rancher_version: v1.5.0
   # maximum_rancher_version:


### PR DESCRIPTION
Upgrades the runner image to 11.1.0 to support latest versions of GitLab.