### PR TITLE
AWX: RabbitMQ credentials are not passed to docker container

### DIFF
--- a/templates/awx/0/docker-compose.yml.tpl
+++ b/templates/awx/0/docker-compose.yml.tpl
@@ -97,6 +97,8 @@ services:
     environment:
       RABBITMQ_ERLANG_COOKIE: awx-erlang-cookie
       RABBITMQ_DEFAULT_VHOST: ${RABBITMQ_VHOST}
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
     stdin_open: true
     tty: true
 {{- end }}


### PR DESCRIPTION
Basically the RabbitMQ connection only works with the default guest user credentials. 